### PR TITLE
Default parameters now main.nf to address setting priority issues

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -9,6 +9,12 @@ params.illum         = false    // whether to run ImageJ+BaSiC
 params.tma           = false    // whether to run Coreograph
 params.skipAshlar    = false    // whether to skip ASHLAR
 
+// Default parameters for individual modules
+params.ashlarOpts  = '-m 30 --pyramid'
+params.unmicstOpts = ''
+params.s3segOpts   = ''
+params.quantOpts   = ''
+
 // Define all subdirectories
 path_raw   = "${params.in}/raw_images"
 path_qc    = "${params.in}/qc"

--- a/nextflow.config
+++ b/nextflow.config
@@ -9,12 +9,6 @@ params.unmicstVersion = '1.0.0'
 params.s3segVersion   = '0.2.2'
 params.quantVersion   = '1.2.2'
 
-// Default parameters for individual modules
-params.ashlarOpts  = '-m 30 --pyramid'
-params.unmicstOpts = ''
-params.s3segOpts   = ''
-params.quantOpts   = ''
-
 // Platform-specific profiles
 profiles {
 


### PR DESCRIPTION
It seems nextflow priority for parameter specification is:
1. Command line
2. nextflow.config
3. YAML file supplied through `-params-file`
4. Defaults in main.nf

Since nextflow.config was preventing users from overwriting default module parameters, I moved those from nextflow.config to main.nf.