### PR TITLE
updated cluster options based off Janae's and Ajit's run

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -47,4 +47,39 @@ profiles {
       withName:quantification {clusterOptions = '-t 12:00:00 --mem=128000'}
     }	    
   }
+  
+  // for running a small (<= 30 cores) TMA on O2 such as exemplar-002
+  O2TMA {
+    includeConfig 'config/O2base.config'
+    
+    process {
+      queue = 'short'
+      withName:illumination   {clusterOptions = '-t 1:00:00 --mem=16000'}
+      withName:dearray        {clusterOptions = '-t 3:00:00 -c 5 --mem=64000'}
+      withName:ashlar         {clusterOptions = '-t 6:00:00 --mem=64000'}
+      withName:unmicst        {clusterOptions = '-t 1:00:00 --mem=16000'}
+      withName:ilastik        {clusterOptions = '-t 12:00:00 --mem=128000'}
+      withName:s3seg          {clusterOptions = '-t 1:00:00 --mem=64000'}
+      withName:quantification {clusterOptions = '-t 12:00:00 --mem=128000'}
+    }	    
+  }
+  
+    // for running a large (> 30 cores) TMA on O2 
+  O2TMAlarge {
+    includeConfig 'config/O2base.config'
+    
+    process {
+      queue = 'short'
+      withName:illumination   {clusterOptions = '-t 1:00:00 --mem=16000'}
+      withName:dearray        {clusterOptions = '-t 6:00:00 -c 10 --mem=128000'}
+      withName:ashlar         {clusterOptions = '-t 6:00:00 --mem=64000'}
+      withName:unmicst        {clusterOptions = '-t 1:00:00 --mem=16000'}
+      withName:ilastik        {clusterOptions = '-t 12:00:00 --mem=128000'}
+      withName:s3seg          {clusterOptions = '-t 1:00:00 --mem=64000'}
+      withName:quantification {clusterOptions = '-t 12:00:00 --mem=128000'}
+    }	    
+  }
+  
+  
+  
 }


### PR DESCRIPTION
-added O2TMA and O2TMAlarge for small and large datasets respectively. O2TMA will request half the time and CPU cores for Coreograph as O2TMAlarge. Both have the same memory and time requirements after the dearray step.