### PR TITLE
Fixed the workdir null issue

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -298,8 +298,9 @@ workflow.onComplete {
     // Combine the provenance of all tasks into a single channel
     // Store commands and logs
     prov1.mix(prov2, prov3, prov4_unmicst, prov4_ilastik, prov5, prov6)
-	.subscribe { name, wkdir ->
-	file("${wkdir}/.command.sh").copyTo("${path_prov}/${name}.sh")
-	file("${wkdir}/.command.log").copyTo("${path_prov}/${name}.log")
+	.subscribe { name, wkdir ->  if( wkdir != null ) {
+	    file("${wkdir}/.command.sh").copyTo("${path_prov}/${name}.sh")
+	    file("${wkdir}/.command.log").copyTo("${path_prov}/${name}.log")
+	}
     }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,11 +1,11 @@
 // Version of the pipeline as a whole
 // (Has no meaning outside of O2)
-params.mcmicroVersion = '2020-05-19'
+params.mcmicroVersion = '2020-05-27'
 
 // Versions of individual modules
 params.illumVersion     = '1.0.0'
 params.ashlarVersion    = '1.11.1'
-params.unmicstVersion   = '1.2.1'
+params.unmicstVersion   = '1.2.2'
 params.mcilastikVersion = '1.0.1'
 params.s3segVersion     = '0.3.0'
 params.quantVersion     = '1.2.2'


### PR DESCRIPTION
-Fixed the issue of cached processes returning `null` working directories, leading to "null/.command.sh not found" errors during provenance reconstruction
-Bumped version of UnMicst up to 1.2.2

Closes #135 