### PR TITLE
Update quantification to 1.3.3 - see WARNING

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -1,6 +1,6 @@
 // Version of the pipeline as a whole
 // (Has no meaning outside of O2)
-params.mcmicroVersion = '2020-05-27'
+params.mcmicroVersion = '2020-06-03'
 
 // Versions of individual modules
 params.illumVersion     = '1.0.0'

--- a/nextflow.config
+++ b/nextflow.config
@@ -8,7 +8,7 @@ params.ashlarVersion    = '1.11.1'
 params.unmicstVersion   = '1.2.2'
 params.mcilastikVersion = '1.0.1'
 params.s3segVersion     = '0.3.0'
-params.quantVersion     = '1.2.2'
+params.quantVersion     = '1.3.0'
 
 // Platform-specific profiles
 profiles {


### PR DESCRIPTION
WARNING:
This release changes naming for X and Y coordinates of cellular centroid position and adds column and row representation according to #18