### PR TITLE
New module for cell state calling and UMAP generation

### DIFF
--- a/O2conda.sh
+++ b/O2conda.sh
@@ -7,3 +7,9 @@ conda env create -f conda/unmicst.yml        -p "$1/unmicst-2020-06-06"
 conda env create -f conda/s3seg.yml          -p "$1/s3seg"
 conda env create -f conda/quantification.yml -p "$1/quantification"
 conda env create -f conda/mc_ilastik.yml     -p "$1/mc_ilastik"
+conda env create -f conda/nstates.yml        -p "$1/naivestates"
+
+## Additional dependencies
+conda activate "$1/naivestates"
+R -s -e "devtools::install_github('labsyspharm/naivestates')"
+conda deactivate

--- a/conda/nstates.yml
+++ b/conda/nstates.yml
@@ -1,0 +1,11 @@
+name: naivestates
+channels:
+  - conda-forge
+dependencies:
+  - r-tidyverse=1.3.0
+  - r-mixtools=1.2.0
+  - r-egg=0.4.5
+  - r-devtools=2.3.0
+  - r-optparse=1.6.6
+  - r-ggthemes=4.2.0
+  - r-uwot=0.1.8

--- a/config/O2base.config
+++ b/config/O2base.config
@@ -10,6 +10,7 @@ params.tool_ilastik   = "${params.tools}/ilastik-release"
 params.tool_mcilastik = "${params.tools}/mcmicro-ilastik"
 params.tool_segment   = "${params.tools}/S3segmenter"
 params.tool_quant     = "${params.tools}/quantification"
+params.tool_nstates   = "${params.tools}/naivestates"
 
 process {
   executor = 'slurm'
@@ -19,4 +20,5 @@ process {
   withName:ilastik        {conda = "${params.O2conda}/mc_ilastik"}
   withName:s3seg          {conda = "${params.O2conda}/s3seg"}
   withName:quantification {conda = "${params.O2conda}/quantification"}
+  withName:naivestates    {conda = "${params.O2conda}/naivestates"}
 }

--- a/config/standard.config
+++ b/config/standard.config
@@ -11,7 +11,8 @@ params.tool_unmicst   = '/app'
 params.tool_ilastik   = '/ilastik-release'
 params.tool_mcilastik = '/app'
 params.tool_segment   = '/app'
-params.tool_quant     = '/app' 
+params.tool_quant     = '/app'
+params.tool_nstates   = '/app'
 
 process {
   withName:illumination   {container = "labsyspharm/basic-illumination:${params.illumVersion}"}
@@ -20,4 +21,5 @@ process {
   withName:ilastik        {container = "labsyspharm/mcmicro-ilastik:${params.mcilastikVersion}"}
   withName:s3seg          {container = "labsyspharm/s3segmenter:${params.s3segVersion}"}
   withName:quantification {container = "labsyspharm/quantification:${params.quantVersion}"}
+  withName:naivestates    {container = "labsyspharm/naivestates:${params.nstatesVersion}"}
 }

--- a/main.nf
+++ b/main.nf
@@ -320,7 +320,7 @@ workflow.onComplete {
 
     // Combine the provenance of all tasks into a single channel
     // Store commands and logs
-    prov1.mix(prov2, prov3, prov4_unmicst, prov4_ilastik, prov5, prov6)
+    prov1.mix(prov2, prov3, prov4_unmicst, prov4_ilastik, prov5, prov6, prov7)
 	.subscribe { name, wkdir ->  if( wkdir != null ) {
 	    file("${wkdir}/.command.sh").copyTo("${path_prov}/${name}.sh")
 	    file("${wkdir}/.command.log").copyTo("${path_prov}/${name}.log")

--- a/main.nf
+++ b/main.nf
@@ -284,16 +284,6 @@ process quantification {
     """
 }
 
-/*
-process naivestates {
-    input: file(counts) from s6out
-
-    """
-    ls $counts
-    """
-}*/
-
-
 // Step 7 output
 process naivestates {
     publishDir path_states, mode: 'copy', pattern: '*.csv'
@@ -309,7 +299,8 @@ process naivestates {
     when: idxStop >= 7
 
     """
-    ${params.tool_nstates}/main.R -i $counts -o . ${params.nstatesOpts}
+    ${params.tool_nstates}/main.R -i $counts -o . ${params.nstatesOpts} \
+    --mct ${params.tool_nstates}/typemap.csv
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -6,7 +6,7 @@
 // Default parameters for the pipeline as a whole
 params.sample_name = file(params.in).name
 params.startAt     = 'registration'
-params.stopAt      = 'quantification'
+params.stopAt      = 'cell-states'
 params.tma         = false    // whether to run Coreograph
 
 // Default selection of methods for each step
@@ -17,6 +17,7 @@ params.ashlarOpts  = '-m 30'
 params.unmicstOpts = ''
 params.s3segOpts   = ''
 params.quantOpts   = ''
+params.nstatesOpts = '--plots --log auto --id CellID'
 
 // Path-specific parameters that cannot be captured by the above *opts
 params.quantificationMask = 'cellMask.tif'
@@ -32,7 +33,8 @@ mcmsteps = ["raw",		// Step 0
 	    "dearray",		// Step 3
 	    "probability-maps", // Step 4
 	    "segmentation",	// Step 5
-	    "quantification"]	// Step 6
+	    "quantification",	// Step 6
+	    "cell-states"]      // Step 7
 
 // Identify starting and stopping index
 idxStart = mcmsteps.indexOf( params.startAt )
@@ -52,14 +54,15 @@ if( idxStart > 4 )
   error "Starting at steps beyond probability map computation is not yet supported."
 
 // Define all subdirectories
-path_raw   = "${params.in}/${mcmsteps[0]}"
-path_ilp   = "${params.in}/${mcmsteps[1]}"
-path_rg    = "${params.in}/${mcmsteps[2]}"
-path_dr    = "${params.in}/${mcmsteps[3]}"
-path_prob  = "${params.in}/${mcmsteps[4]}"
-path_seg   = "${params.in}/${mcmsteps[5]}"
-path_quant = "${params.in}/${mcmsteps[6]}"
-path_qc    = "${params.in}/qc"
+path_raw    = "${params.in}/${mcmsteps[0]}"
+path_ilp    = "${params.in}/${mcmsteps[1]}"
+path_rg     = "${params.in}/${mcmsteps[2]}"
+path_dr     = "${params.in}/${mcmsteps[3]}"
+path_prob   = "${params.in}/${mcmsteps[4]}"
+path_seg    = "${params.in}/${mcmsteps[5]}"
+path_quant  = "${params.in}/${mcmsteps[6]}"
+path_states = "${params.in}/${mcmsteps[7]}"
+path_qc     = "${params.in}/qc"
 
 // Check that deprecated locations are empty
 msg_dprc = {a,b -> "The use of $a has been deprecated. Please use $b instead."}
@@ -268,7 +271,7 @@ process quantification {
 
     input:  tuple file(core), file(mask), file(ch) from s5out
     output:
-      file '**' into s6out
+      file ('*.csv') into s6out
       tuple val(task.name), val(task.workDir) into prov6
 
     when: idxStop >= 6
@@ -278,6 +281,35 @@ process quantification {
     --mask $mask --image $core \
     ${params.quantOpts} \
     --output . --channel_names $ch
+    """
+}
+
+/*
+process naivestates {
+    input: file(counts) from s6out
+
+    """
+    ls $counts
+    """
+}*/
+
+
+// Step 7 output
+process naivestates {
+    publishDir path_states, mode: 'copy', pattern: '*.csv'
+    publishDir path_states, mode: 'copy', pattern: 'plots/*.pdf'
+    publishDir "${path_qc}/naivestates", mode: 'copy', pattern: 'plots/*/*.pdf',
+      saveAs: { fn -> fn.replaceFirst("plots/","") }
+    
+    input: file(counts) from s6out
+    output:
+      file '**' into s7out
+      tuple val(task.name), val(task.workDir) into prov7
+
+    when: idxStop >= 7
+
+    """
+    ${params.tool_nstates}/main.R -i $counts -o . ${params.nstatesOpts}
     """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,6 +1,6 @@
 // Version of the pipeline as a whole
 // (Has no meaning outside of O2)
-params.mcmicroVersion = '2020-06-06'
+params.mcmicroVersion = '2020-06-12'
 
 // Versions of individual modules
 params.illumVersion     = '1.0.1'
@@ -30,6 +30,7 @@ profiles {
       withName:ilastik        {clusterOptions = '-t 1:00:00 --mem=32000'}
       withName:s3seg          {clusterOptions = '-t 1:00:00 --mem=4000'}
       withName:quantification {clusterOptions = '-t 1:00:00 --mem=16000'}
+      withName:naivestates    {clusterOptions = '-t 1:00:00 --mem=16000'}
     }
   }
 
@@ -46,6 +47,7 @@ profiles {
       withName:ilastik        {clusterOptions = '-t 12:00:00 --mem=128000'}
       withName:s3seg          {clusterOptions = '-t 12:00:00 --mem=128000'}
       withName:quantification {clusterOptions = '-t 12:00:00 --mem=128000'}
+      withName:naivestates    {clusterOptions = '-t 12:00:00 --mem=128000'}
     }	    
   }
   
@@ -62,6 +64,7 @@ profiles {
       withName:ilastik        {clusterOptions = '-t 12:00:00 --mem=230000'}
       withName:s3seg          {clusterOptions = '-t 12:00:00 --mem=230000'}
       withName:quantification {clusterOptions = '-t 12:00:00 --mem=128000'}
+      withName:naivestates    {clusterOptions = '-t 12:00:00 --mem=128000'}
     }	    
   }
   
@@ -78,6 +81,7 @@ profiles {
       withName:ilastik        {clusterOptions = '-t 12:00:00 --mem=128000'}
       withName:s3seg          {clusterOptions = '-t 1:00:00 --mem=64000'}
       withName:quantification {clusterOptions = '-t 12:00:00 --mem=128000'}
+      withName:naivestates    {clusterOptions = '-t 12:00:00 --mem=128000'}
     }	    
   }
   
@@ -94,9 +98,8 @@ profiles {
       withName:ilastik        {clusterOptions = '-t 12:00:00 --mem=128000'}
       withName:s3seg          {clusterOptions = '-t 1:00:00 --mem=64000'}
       withName:quantification {clusterOptions = '-t 12:00:00 --mem=128000'}
+      withName:naivestates    {clusterOptions = '-t 12:00:00 --mem=128000'}
     }	    
   }
-  
-  
   
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,10 +5,11 @@ params.mcmicroVersion = '2020-06-06'
 // Versions of individual modules
 params.illumVersion     = '1.0.1'
 params.ashlarVersion    = '1.11.1'
-params.unmicstVersion   = '1.3.2'
+params.unmicstVersion   = '1.3.4'
 params.mcilastikVersion = '1.0.1'
 params.s3segVersion     = '0.3.0'
 params.quantVersion     = '1.3.0'
+params.nstatesVersion   = '1.2.0'
 
 // Platform-specific profiles
 profiles {

--- a/setup.nf
+++ b/setup.nf
@@ -115,3 +115,16 @@ process setup_quantification {
     """
 }
 
+process setup_naivestates {
+    executor 'local'
+    publishDir params.tools, mode: 'copy'
+
+    output: file '**' into tool_nstates
+    when: workflow.profile == "O2"
+
+    """
+    git clone https://github.com/labsyspharm/naivestates.git
+    cd naivestates
+    git checkout tags/${params.nstatesVersion}
+    """
+}


### PR DESCRIPTION
The pull request adds `naivestates` (https://github.com/labsyspharm/naivestates) to the pipeline. The module accepts quantified marker expression and performs three things:

1. Converts raw expression values to probabilities, thus mapping values to the [0,1] range and allowing for direct comparison between markers.
2. Performs basic cell state inference based on dominant marker (i.e., marker with the highest probability of expression).
3. Generates a summary UMAP, where each cell is colored by the inferred cell state and/or dominant marker.

Probabilities, cell states inferences and UMAP plots are written to `project/cell-states`. Additional QC plots of Gaussian mixture fits are written to `project/qc/naivestates`.

Closes #110 