### PR TITLE
Processing of multiple masks in parallel

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -7,7 +7,7 @@ params.illumVersion     = '1.0.1'
 params.ashlarVersion    = '1.11.1'
 params.unmicstVersion   = '1.3.4'
 params.mcilastikVersion = '1.0.1'
-params.s3segVersion     = '0.3.1'
+params.s3segVersion     = '0.3.0'
 params.quantVersion     = '1.3.1'
 params.nstatesVersion   = '1.3.0'
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,6 +1,6 @@
 // Version of the pipeline as a whole
 // (Has no meaning outside of O2)
-params.mcmicroVersion = '2020-06-12'
+params.mcmicroVersion = '2020-06-20'
 
 // Versions of individual modules
 params.illumVersion     = '1.0.1'

--- a/nextflow.config
+++ b/nextflow.config
@@ -7,9 +7,9 @@ params.illumVersion     = '1.0.1'
 params.ashlarVersion    = '1.11.1'
 params.unmicstVersion   = '1.3.4'
 params.mcilastikVersion = '1.0.1'
-params.s3segVersion     = '0.3.0'
-params.quantVersion     = '1.3.0'
-params.nstatesVersion   = '1.2.0'
+params.s3segVersion     = '0.3.1'
+params.quantVersion     = '1.3.1'
+params.nstatesVersion   = '1.3.0'
 
 // Platform-specific profiles
 profiles {


### PR DESCRIPTION
-Added `--mask-spatial` and `--mask-add` to feed multiple masks to quantification
-Deprecated `--quantification-mask`
-Adjusted `naivestates` to work with modified quantification output
-Tested on exemplar-001 and -002, locally and on O2.

Closes #121 