### PR TITLE
fixed GPU singularity compatibility

### DIFF
--- a/config/gpu.config
+++ b/config/gpu.config
@@ -1,0 +1,36 @@
+process {
+  withName:illumination   {
+    time   = '6h'
+    memory = '64G'
+  }
+  withName:dearray        {
+    time   = '1h'
+    memory = '64G'
+  }
+  withName:ashlar         {
+    time   = '6h'
+    memory = '64G'
+  }
+  withName:'unmicst.*'    {
+    time   = '1h'
+    memory = '128G'
+  }
+  withName:ilastik        {
+    cpus   = 8
+    time   = '12h'
+    memory = '128G'
+  }
+  withName:s3seg          {
+    cpus   = 6
+    time   = '6h'
+    memory = '80G'
+  }
+  withName:quantification {
+    time   = '12h'
+    memory = '128G'
+  }
+  withName:naivestates    {
+    time   = '12h'
+    memory = '128G'
+  }
+}

--- a/config/gpu.config
+++ b/config/gpu.config
@@ -14,6 +14,8 @@ process {
   withName:'unmicst.*'    {
     time   = '1h'
     memory = '128G'
+    queue = 'gpu'
+    clusterOptions = '--gres=gpu:1'
   }
   withName:ilastik        {
     cpus   = 8

--- a/config/singularity.config
+++ b/config/singularity.config
@@ -1,6 +1,6 @@
 singularity.enabled    = true
 singularity.autoMounts = true
-singularity.runOptions = '-C'
+singularity.runOptions = '-C --nv'
 singularity.cacheDir   = '/n/groups/lsp/mcmicro/singularity'
 
 process {

--- a/nextflow.config
+++ b/nextflow.config
@@ -2,9 +2,9 @@
 params.illumVersion     = '1.0.1'
 params.ashlarVersion    = '1.11.1'
 params.coreoVersion     = '2.2.0'
-params.unmicstVersion   = '2.2.0'
+params.unmicstVersion   = '2.4.3-gpu'
 params.mcilastikVersion = '1.4.0'
-params.s3segVersion     = '1.1.3'
+params.s3segVersion     = '1.2.0'
 params.quantVersion     = '1.3.1'
 params.nstatesVersion   = '1.3.0'
 
@@ -35,10 +35,14 @@ profiles {
   // Same as O2massive but with GPU support for selected processes
   O2gpu {
     includeConfig 'config/O2base.config'
-    includeConfig 'config/massive.config'
+    includeConfig 'config/gpu.config'
     
     process {
       withName:unmicst {
+        queue = 'gpu'
+        clusterOptions = '--gres=gpu:1'
+      }
+      withName:unmicst2 {
         queue = 'gpu'
         clusterOptions = '--gres=gpu:1'
       }

--- a/nextflow.config
+++ b/nextflow.config
@@ -36,17 +36,6 @@ profiles {
   O2gpu {
     includeConfig 'config/O2base.config'
     includeConfig 'config/gpu.config'
-    
-    process {
-      withName:unmicst {
-        queue = 'gpu'
-        clusterOptions = '--gres=gpu:1'
-      }
-      withName:unmicst2 {
-        queue = 'gpu'
-        clusterOptions = '--gres=gpu:1'
-      }
-    }	    
   }
 
   // Processing TMAs on O2


### PR DESCRIPTION
-fixed bug in dockerfile loading wrong tensorflow container
-rewrote GPUselect since nvidia-smi does not work inside containers, therefore, cannot determine which GPU is free
-added a GPU profile to O2 with shorter time requirements
-updated s3segmenter and unmicst versions