### PR TITLE
Segmentation masks are now specified via `--quant-opts`

### DIFF
--- a/docs/_includes/params.md
+++ b/docs/_includes/params.md
@@ -23,21 +23,20 @@ tma: true
 * `--stop-at <step>` - name of the final step to be executed by the pipeline. Spans the same vocabulary as `--start-at`. Default: `cell-states`.
 * `--tma` - if specified, mcmicro treats input data as a TMA. If omitted, the input is assumed to be a whole-slide image. Default: omitted.
 * `--raw-formats <formats>` - one or more file formats that mcmicro should look for. Default: `{.ome.tiff,.ome.tif,.rcpnl,.xdce,.nd,.scan,.htd,.btf,.nd2,.tif,.czi}`
+* `--ilastik-model` - A custom `.ilp` file to be used as the classifier model for ilastik
 
 **Module selection**
 * `--probability-maps <unmicst|ilastik|all>` - which module(s) to use for probability map computation. Default: `unmicst`
 
 ## Parameters for individual modules
 
-It is important to make a distinction between parameters that control the behavior of individual modules, and parameters that specify which files the modules operate on. Because all file management is done at the level of the pipeline, **the latter set is marked with `[mcmicro]` in the below lists to indicate that the parameters must be provided to mcmicro instead.**
+Module-specific parameters can be specified using the various `opts` arguments, followed by the parameters enclosed inside single quotes `'`:
 
 Example 1: `nextflow run labsyspharm/mcmicro --in /my/data --ashlar-opts '-m 30 --pyramid'`
 
 Example 2: `nextflow run labsyspharm/mcmicro --in /my/data --nstates-opts '--log no --plots pdf'`
 
-Example 3: `nextflow run labsyspharm/mcmicro --in /my/data --mask-add 'cytoMask.tif nucleiMask.tif'`
-
-Note that because `cytoMask.tif` and `nucleiMask.tif` reference filenames, the argument `--mask-add` is provided directly to nextflow, as opposed to `--quant-opts`.
+Example 3: `nextflow run labsyspharm/mcmicro --in /my/data --quant-opts '--masks cytoMask.tif nucleiMask.tif'`
 
 ### Arguments to ASHLAR (`--ashlar-opts`):
 
@@ -68,7 +67,6 @@ Up-to-date list can be viewed at [https://github.com/HMS-IDAC/UNetCoreograph](ht
 * `--channelIDs` - Integer indices specifying which channels to export (Ex: 1 2 4)
 * `--ring_mask` - Include if you have a ring mask in the same directory to use for reducing size of hdf5 image. do not include if not
 * `--crop_amount` -  Number of crops you would like to extract
-* **[mcmicro]** `--ilastik-model` - A custom `.ilp` file to be used as the classifier model
 
 Up-to-date list can be viewed at [https://github.com/labsyspharm/mcmicro-ilastik](https://github.com/labsyspharm/mcmicro-ilastik)
 
@@ -89,9 +87,6 @@ Up-to-date list can be viewed at [https://github.com/labsyspharm/mcmicro-ilastik
 * `--TissueMaskChan` - select one or more channels to use for identifying the general tissue area for masking purposes. Default is to use a combination of nuclei and cytoplasm channels.
 
 ### Arguments to quantification(`--quant-opts`):
-
-* **[mcmicro]** `--mask-spatial <filename>` - which segmentation mask should be used for extracting spatial features. Must be a filename produced by the s3segmenter. Default: `cellMask.tif`
-* **[mcmicro]** `--mask-add <filenames>` - one or more filenames referencing masks produced by the s3segmenter that should also be quantified. The filenames should be surrounded with single quotes (`'`). Default: none.
 
 Up-to-date list can be viewed at [https://github.com/labsyspharm/quantification](https://github.com/labsyspharm/quantification)
 

--- a/main.nf
+++ b/main.nf
@@ -33,7 +33,7 @@ params.unmicstOpts  = ''
 params.unmicst2Opts = '--channel 0'
 params.ilastikOpts  = '--num_channels 1'
 params.s3segOpts    = ''
-params.quantOpts    = '--mask cellMask.tif'
+params.quantOpts    = '--masks cellMask.tif'
 params.nstatesOpts  = '-p png'
 
 // Path-specific parameters that cannot be captured by the above *opts
@@ -51,9 +51,9 @@ if( params.quantificationMask != '' )
 if( params.illum )
     error "--illum is deprecated; please use --start-at illumination"
 if( params.maskSpatial != '' )
-    error "--maskSpatial is deprecated; please use --quant-opts '--mask ...'"
+    error "--maskSpatial is deprecated; please use --quant-opts '--masks ...'"
 if( params.maskAdd != '' )
-    error "--maskAdd is deprecated; please use --quant-opts '--mask ...'"
+    error "--maskAdd is deprecated; please use --quant-opts '--masks ...'"
 
 // Steps in the mcmicro pipeline
 mcmsteps = ["raw",		// Step 0

--- a/main.nf
+++ b/main.nf
@@ -33,11 +33,11 @@ params.unmicstOpts  = ''
 params.unmicst2Opts = '--channel 0'
 params.ilastikOpts  = '--num_channels 1'
 params.s3segOpts    = ''
-params.quantOpts    = ''
+params.quantOpts    = '--mask cellMask.tif'
 params.nstatesOpts  = '-p png'
 
 // Path-specific parameters that cannot be captured by the above *opts
-params.maskSpatial  = 'cellMask.tif'
+params.maskSpatial  = ''
 params.maskAdd      = ''
 params.ilastikModel = 'built-in'
 
@@ -50,6 +50,10 @@ if( params.quantificationMask != '' )
     error "--quantification-mask is deprecated; please use --mask-spatial and --mask-add instead"
 if( params.illum )
     error "--illum is deprecated; please use --start-at illumination"
+if( params.maskSpatial != '' )
+    error "--maskSpatial is deprecated; please use --quant-opts '--mask ...'"
+if( params.maskAdd != '' )
+    error "--maskAdd is deprecated; please use --quant-opts '--mask ...'"
 
 // Steps in the mcmicro pipeline
 mcmsteps = ["raw",		// Step 0
@@ -80,14 +84,6 @@ Channel.fromPath( "${params.in}/illumination_profiles/*" )
 
 // Identify marker information
 chMrk = Channel.fromPath( "${params.in}/markers.csv", checkIfExists: true )
-
-// Determine which masks will be needed by quantification
-masks = params.maskAdd.tokenize()
-switch( masks.size() ) {
-    case 0: params.qtym = ""; break;
-    case 1: params.qtym = "**${masks[0]}"; break;
-    default: params.qtym = "**{${masks.join(',')}}"
-}
 
 // Helper functions for finding raw images and precomputed intermediates
 findFiles0 = { p, path -> p ?
@@ -133,12 +129,9 @@ pre_ilastik = findFiles(idxStart == 5 &&
 			 params.probabilityMaps == 'all'),
 			"${paths[4]}/ilastik/*Probabilities*.tif",
 			{error "No probability maps found in ${paths[4]}/ilastik"})
-pre_sptMsk = findFiles(idxStart == 6,
-		       "${paths[5]}/**${params.maskSpatial}",
-		       {error "No spatial masks in ${paths[5]}"})
-pre_addMsk = findFiles(idxStart == 6 && params.qtym != '',
-		       "${paths[5]}/${params.qtym}",
-		       {error "No additional masks in ${paths[5]}"})
+pre_segMsk = findFiles(idxStart == 6,
+		       "${paths[5]}/**Mask.tif",
+		       {error "No segmentation masks in ${paths[5]}"})
 pre_qty    = findFiles(idxStart == 7,
 		       "${paths[6]}/*.csv",
 		       {error "No quantification tables in ${paths[6]}"})
@@ -151,24 +144,19 @@ id_unmicst = pre_unmicst.map{ f -> getID(f,'_Probabilities') }
     .map{ id, f -> tuple(id, f, 'unmicst') }
 id_ilastik = pre_ilastik.map{ f -> getID(f,'_Probabilities') }
     .map{ id, f -> tuple(id, f, 'ilastik') }
-id_sptMsk  = pre_sptMsk.map{ f -> tuple(f.getParent().getBaseName(), f) }
-id_addMsk  = pre_addMsk.map{ f -> tuple(f.getParent().getBaseName(), f) }
-    .groupTuple()
-id_qtyMsk  = (params.qtym == '' ?
-	      id_sptMsk.map{ id, m -> tuple(id, m, []) } :
-	      id_sptMsk.join( id_addMsk ))
-    .map{ id, sm, am -> x = id.split('-',2); tuple(x[1], x[0], sm, am) }
+id_segMsk  = pre_segMsk.map{ f -> tuple(f.getParent().getBaseName(), f) }
+    .groupTuple().map{ id, msk -> x = id.split('-',2); tuple(x[1], x[0], msk) }
 
 // Match up precomputed intermediates into tuples for each step
 id_cm   = id_cores.join( id_masks )
 id_cm2  = id_img.map{ id, x -> tuple(id, x, 'NO_MASK') }.mix(id_cm)
 id_pmap = id_cm2.join( id_unmicst ).mix( id_cm2.join( id_ilastik ) )
-id_qty  = id_img.mix( id_cores ).combine( id_qtyMsk, by:0 )
+id_seg  = id_img.mix( id_cores ).combine( id_segMsk, by:0 )
 
 // Finalize the tuple format to match process outputs
 pre_tma  = id_cm.map{ id, c, m -> tuple(c,m) }
 pre_pmap = id_pmap.map{ id, c, m, p, mtd -> tuple(mtd,c,m,p) }
-pre_seg  = id_qty.map{ id, i, mtd, sm, am -> tuple(mtd,i,sm,am) }
+pre_seg  = id_seg.map{ id, i, mtd, msk -> tuple(mtd,i,msk) }
 
 // The following parameters are shared by all modules
 params.idxStart  = idxStart
@@ -216,9 +204,8 @@ workflow {
 
     // Append markers.csv to every tuple
     segmentation.out.mix(pre_seg)
-	.combine(chMrk)
-	.map{ mtd, c, ms, ma, ch ->
-          tuple("${mtd}-${c.getName()}", c, ms, ma, ch) } |
+	.map{ mtd, c, msk -> tuple("${mtd}-${c.getName()}", c, msk) }
+    	.combine(chMrk) |
 	quantification
 
     // Cell type callers

--- a/modules/quantification.nf
+++ b/modules/quantification.nf
@@ -9,8 +9,7 @@ process quantification {
       saveAs: {fn -> "${task.name}.log"}
     
     input:
-	tuple val(tag), path("$tag"),
-          path(maskSpt), path(maskAdd), path(ch)
+	tuple val(tag), path("$tag"), path(masks), path(ch)
     output:
 	path '*.csv', emit: tables
         tuple path('.command.sh'), path('.command.log')
@@ -18,8 +17,7 @@ process quantification {
     when: params.idxStart <= 6 && params.idxStop >= 6
 
     """
-    python /app/CommandSingleCellExtraction.py \
-    --mask $maskSpt $maskAdd --image $tag \
+    python /app/CommandSingleCellExtraction.py --image $tag \
     ${params.quantOpts} --output . --channel_names $ch
     """
 }

--- a/modules/segmentation.nf
+++ b/modules/segmentation.nf
@@ -18,11 +18,10 @@ process s3seg {
 	tuple val(tag), val(method), path(core), file('mask.tif'), path(probs)
 
     output:
-	// tuples for quantification
-        tuple val(method), path(core), path("**${params.maskSpatial}"),
-          path("$params.qtym"), emit: segmasks
+	// output for quantification
+        tuple val(method), path(core), path("**Mask.tif"), emit: segmasks
 
-        // rest of the files for publishDir
+        // qc and provenance
         path('**')
         tuple path('.command.sh'), path('.command.log')
 


### PR DESCRIPTION
Retired `--mask-spatial` and `--mask-add` arguments to the pipeline. These are now handled by the module-specific `--masks` inside `--quant-opts`. For example,

```
nextflow run labsyspharm/mcmicro --in ~/data/exemplar-001 --quant-opts '--masks nucleiMask.tif cellMask.tif'
```

instead of the old

```
nextflow run labsyspharm/mcmicro --in ~/data/exemplar-001 --mask-spatial nucleiMask.tif --mask-add cellMask.tif
```

Closes #202 