### PR TITLE
Add jekyll-remote-theme to support local jekyll runs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -33,6 +33,7 @@ ga_tracking_anonymize_ip: true # Use GDPR compliant Google Analytics settings
 
 plugins:
   - jekyll-seo-tag
+  - jekyll-remote-theme
 
 
 repository: labsyspharm/mcmicro


### PR DESCRIPTION
With this (and `gem install`-ing jekyll-remote-theme) you can run `jekyll serve -w` for a local edit/build/review cycle.