### PR TITLE
Small docs improvements

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -20,13 +20,14 @@ aux_links_new_tab: false
 back_to_top: true
 back_to_top_text: "Back to top"
 
-footer_content: "&copy; 2020 Laboratory of Systems Pharmacology. Distributed by an <a href=\"\">MIT license.</a>"
-
 last_edit_timestamp: true
 last_edit_time_format: "%b %e %Y" # format: https://ruby-doc.org/stdlib-2.7.0/libdoc/time/rdoc/Time.html
 
+license_name: "MIT License"
+license_url: "https://github.com/labsyspharm/mcmicro/blob/master/LICENSE"
 
-# Google Analytics 
+
+# Google Analytics
 ga_tracking: G-EBP7DZSHEP
 ga_tracking_anonymize_ip: true # Use GDPR compliant Google Analytics settings
 

--- a/docs/_includes/footer_custom.html
+++ b/docs/_includes/footer_custom.html
@@ -1,0 +1,3 @@
+<p class="text-small text-grey-dk-100 mb-0">
+    {{ site.title }} is licensed under the <a href="{{ site.license_url }}">{{ site.license_name }}</a>
+</p>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,9 +14,11 @@ nav_order: 3
 
 Two exemplars are currently available for demonstration purposes:
 
-* `exemplar-001` is meant to serve as a minimal reproducible example for running all modules of the pipeline, except the dearray step. The exemplar consists of a small lung adenocarcinoma specimen taken from a larger TMA (tissue microarray), imaged using CyCIF with three cycles. Each cycle consists of six four-channel image tiles, for a total of 12 channels. Because the exemplar is small, illumination profiles were precomputed from the entire TMA and included with the raw images.
+* `exemplar-001` is meant to serve as a minimal reproducible example for running all modules of the pipeline, except the dearray step. The exemplar consists of a small lung adenocarcinoma specimen taken from a larger TMA (tissue microarray), imaged using CyCIF with three cycles. Each cycle consists of six four-channel image tiles, for a total of 12 channels. Because this exemplar is too small for automated illumination correction, illumination profiles were precomputed from the entire TMA and included with the raw images.
 
-* `exemplar-002` is a two-by-two cut-out from a TMA. The four cores are two meningioma tumors, one GI stroma tumor, and one normal colon specimen. The exemplar is meant to test the dearray step, followed by processing of all four cores in parallel.
+* `exemplar-002` is a two-by-two cut-out from a TMA. The four cores are two meningioma tumors, one GI stroma tumor, and one normal colon specimen. The exemplar is meant to test the dearray step, followed by processing of all four cores in parallel. This dataset has ten cycles with 40 total channels and also includes precomputed illumination profiles.
+
+Note that the representative images above only depict a subset of the full list of image channels present in each dataset.
 
 Both exemplars can be downloaded using the following commands:
 ``` bash
@@ -24,4 +26,3 @@ nextflow run labsyspharm/mcmicro/exemplar.nf --name exemplar-001 --path /local/p
 nextflow run labsyspharm/mcmicro/exemplar.nf --name exemplar-002 --path /local/path/
 ```
 with `/local/path/` pointing to a local directory where the exemplars should be downloaded to.
-


### PR DESCRIPTION
* Move from deprecated footer_content config setting to footer_custom.html,
  as recommended by the just-the-docs docs. License name and URL added as
  config settings for easier maintainability.
* Improve exemplar text under Installation.