### PR TITLE
Allow for custom marker -> cell type mappings

### DIFF
--- a/docs/code_of_conduct.md
+++ b/docs/code_of_conduct.md
@@ -41,7 +41,7 @@ We strive to:
 
 ## Diversity Statement
 
-The MCMCICRO project welcomes and encourages participation by everyone. We are committed to being a community that everyone enjoys being part of. Although we may not always be able to accommodate each individual’s preferences, we try our best to treat everyone kindly.
+The MCMICRO project welcomes and encourages participation by everyone. We are committed to being a community that everyone enjoys being part of. Although we may not always be able to accommodate each individual’s preferences, we try our best to treat everyone kindly.
 
 No matter how you identify yourself or how others perceive you: we welcome you. Though no list can hope to be comprehensive, we explicitly honour diversity in: age, culture, ethnicity, genotype, gender identity or expression, language, national origin, neurotype, phenotype, political beliefs, profession, race, religion, sexual orientation, socioeconomic status, subculture and technical ability, to the extent that these do not conflict with this code of conduct.
 

--- a/main.nf
+++ b/main.nf
@@ -90,8 +90,6 @@ Channel.fromPath( "${params.in}/illumination_profiles/*" )
 chMrk = Channel.fromPath( "${params.in}/markers.csv", checkIfExists: true )
 
 // If specified, identify the marker -> cell type (mct) mapping
-// Adjust the parameters to refer to the local filename, which will be a
-//   symbolic link in the corresponding work directory
 nstatesOpts = params.nstatesOpts.tokenize()
 iMct = nstatesOpts.indexOf("--mct")
 chMct = iMct == -1 ? Channel.fromPath("NO_MCT") :
@@ -235,10 +233,9 @@ workflow {
 	quantification
 
     // Cell type callers
-    naivestates(
-	quantification.out.tables.mix(pre_qty)
-	    .combine(chMct)
-    )
+    quantification.out.tables.mix(pre_qty)
+	.combine(chMct) |
+	naivestates
 }
 
 // Write out parameters used

--- a/modules/cell-states.nf
+++ b/modules/cell-states.nf
@@ -13,7 +13,8 @@ process naivestates {
     publishDir "${params.path_prov}", mode: 'copy', pattern: '.command.log',
       saveAs: {fn -> "${task.name}.log"}
     
-    input:  path(counts)
+    input:
+	tuple path(counts), file(mct)
     output:
 	path('**')
         tuple path('.command.sh'), path('.command.log')

--- a/nextflow.config
+++ b/nextflow.config
@@ -7,7 +7,7 @@ params.cypositoryVersion= '1.0.11'
 params.mcilastikVersion = '1.4.2'
 params.s3segVersion     = '1.2.5'
 params.quantVersion     = '1.3.2'
-params.nstatesVersion   = '1.6.2'
+params.nstatesVersion   = '1.7.0'
 
 // Platform-specific profiles
 profiles {


### PR DESCRIPTION
Users can now provide a custom marker -> cell type / cell state mapping to `naivestates`. The many-to-many mapping must be defined as a `.csv` file with columns `Marker` and `State`. For example, consider the following `mymap.csv`:
```
Marker,State
KERATIN,Tumor
SMA,Stroma
CD45,Immune
CD45,B-cell
CD11B,B-cell
CD45,T-cell
CD3D,T-cell
```

The file can be provided to the module via 
```
nextflow run labsyspharm/mcmicro --in /path/to/exemplar-002 --stop-at cell-states --nstates-opts '--mct mymap.csv'
```

See https://github.com/labsyspharm/naivestates for additional information.

