### PR TITLE
Ensure quantification emits one .csv at a time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,11 +145,12 @@ jobs:
         run: |
           docker rmi -f $(docker images -a -q)
           ./nextflow main.nf --in ~/data/exemplar-001 --start-at registration --stop-at registration
+          ./nextflow clean -f last
           ./nextflow main.nf --in ~/data/exemplar-001 --start-at probability-maps --stop-at probability-maps
           ./nextflow main.nf --in ~/data/exemplar-001 --start-at segmentation --stop-at segmentation
           ./nextflow main.nf --in ~/data/exemplar-001 --start-at quantification --stop-at quantification
+          ./nextflow main.nf --in ~/data/exemplar-001 --start-at quantification --quant-opts '--masks nuclei.ome.tif cell.ome.tif'
           docker rmi -f $(docker images -a -q)
-          ./nextflow clean -f last
           ./nextflow main.nf --in ~/data/exemplar-001 --start-at cell-states --stop-at cell-states --cell-states scimap
           ./nextflow main.nf --in ~/data/exemplar-001 --start-at cell-states --stop-at cell-states --cell-states naivestates
           ./nextflow main.nf --in ~/data/exemplar-001 --start-at cell-states --stop-at cell-states --cell-states fastpg

--- a/modules/quantification.nf
+++ b/modules/quantification.nf
@@ -50,5 +50,5 @@ workflow quantification {
     
     emit:
 
-    mcquant.out.tables
+    mcquant.out.tables.flatten()
 }


### PR DESCRIPTION
- Fixed an issue where quantification of multiple masks was emitting all resulting .csv files at once while downstream code was assuming to be working with a single .csv.
- Added a CI test for quantifying multiple masks at once.


