### PR TITLE
Reworked GPU config profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Test exemplar-001 with Cypository
         run: |
           docker rmi -f $(docker images -a -q)
-          ./nextflow main.nf --in ~/data/exemplar-001 --probability-maps cypository --s3seg-opts '--logSigma 45 300' --stop-at quantification
+          ./nextflow main.nf --in ~/data/exemplar-001 --probability-maps cypository --s3seg-opts '--logSigma 45 300'
           ls ~/data/exemplar-001/*
 
   # One-shot test of exemplar-001 using Ilastik

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+### 2022-02-11
+
+* Added a CHANGES file
+* Reworked GPU config profile to expose all GPUs across all platforms
+  * When running MCMICRO on O2, use `-profile O2,GPU` (command, no space) instead of `-profile O2gpu`
+* `quantification` is now the default stopping point

--- a/main.nf
+++ b/main.nf
@@ -14,7 +14,7 @@ nextflow.enable.dsl=2
 // Default parameters for the pipeline as a whole
 params.sampleName  = file(params.in).name
 params.startAt     = 'registration'
-params.stopAt      = 'cell-states'
+params.stopAt      = 'quantification'
 params.tma         = false    // whether working with a TMA (true) or whole-slide image (false)
 
 // Some image formats store multiple fields of view in a single file. Other

--- a/nextflow.config
+++ b/nextflow.config
@@ -30,33 +30,9 @@ profiles {
     singularity.cacheDir = "$HOME/.mcmicro"
   }
 
-  // Same as O2, but with GPU support for worker processes
-  O2gpu {
-    includeConfig 'config/O2base.config'
-    singularity.runOptions = '-C --nv'
-    
-    process{
-      withName:worker {
-        queue = 'gpu'
-        clusterOptions = '--gres=gpu:1'
-      }
-    }
-  }
-
   // Amazon Web Services
   AWS {
     includeConfig 'config/aws.config'
-  }
-
-  // Same as AWS, but with GPU support for worker processes
-  AWSgpu {
-    includeConfig 'config/aws.config'
-    
-    process {
-      withName:worker {
-        queue = 'mcmicro-queue-gpu'
-      }
-    }
   }
 
   /****************************
@@ -69,6 +45,18 @@ profiles {
 
   TMA {
     includeConfig 'config/tma.config'
+  }
+
+  GPU {
+    docker.runOptions = '--cpus 0.000 --gpus all'
+    singularity.runOptions = '-C --nv'
+    
+    process{
+      withName:worker {
+        queue = 'gpu'
+        clusterOptions = '--gres=gpu:1'
+      }
+    }
   }
 
   /**************************


### PR DESCRIPTION
* Reworked the GPU config profile to work across platforms.
  * Use `-profile O2,GPU` to use GPUs on O2
  * Use `-profile standard,GPU` to use GPUs with Docker on a local system
  * Use `-profile singularity,GPU` to use GPUs with Singularity on a local system
* Made the pipeline stop at `quantification` by default to keep @DenisSch happy.
* Introduced CHANGES.md

Closes #354 