### PR TITLE
Fixed typos; updated tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Test exemplar-001 with Cypository
         run: |
           docker rmi -f $(docker images -a -q)
-          ./nextflow main.nf --in ~/data/exemplar-001 --probability-maps cypository --s3seg-opts '--logSigma 45 300'
+          ./nextflow main.nf --in ~/data/exemplar-001  --probability-maps cypository --s3seg-opts '--logSigma 45 300'
           ls ~/data/exemplar-001/*
 
   # One-shot test of exemplar-001 using Ilastik

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Test exemplar-001 with Cypository
         run: |
           docker rmi -f $(docker images -a -q)
-          ./nextflow main.nf --in ~/data/exemplar-001  --probability-maps cypository --s3seg-opts '--logSigma 45 300'
+          ./nextflow main.nf --in ~/data/exemplar-001  --probability-maps cypository --cypository-opts '--channel 10 --scalingFactor 2' --s3seg-opts '--logSigma 45 300'
           ls ~/data/exemplar-001/*
 
   # One-shot test of exemplar-001 using Ilastik

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/data/exemplar-001
-          key: mcmicro-exemplar-001
+          key: ex001-2022-02-24
       - name: Exemplar-002 cache
         uses: actions/cache@v2
         with:
           path: ~/data/exemplar-002
-          key: mcmicro-exemplar-002-2cycle
+          key: ex002-2022-02-24
 
       # Download data only if no cache is available
       - name: Exemplar-001 download
@@ -48,7 +48,7 @@ jobs:
             echo "Using exemplar-002 cache"
             ls ~/data/exemplar-002/*
           else
-            ./nextflow exemplar.nf --name exemplar-002 --path ~/data --nc 2
+            ./nextflow exemplar.nf --name exemplar-002 --path ~/data --from-cycle 6 --to-cycle 7
           fi
 
   # One-shot test of exemplar-001
@@ -63,7 +63,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/data/exemplar-001
-          key: mcmicro-exemplar-001
+          key: ex001-2022-02-24
       - name: Test exemplar-001
         run: |
           docker rmi -f $(docker images -a -q)
@@ -92,7 +92,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/data/exemplar-001
-          key: mcmicro-exemplar-001
+          key: ex001-2022-02-24
       - name: Test exemplar-001 with Cypository
         run: |
           docker rmi -f $(docker images -a -q)
@@ -111,7 +111,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/data/exemplar-001
-          key: mcmicro-exemplar-001
+          key: ex001-2022-02-24
       - name: Test exemplar-001 with Ilastik
         run: |
           docker rmi -f $(docker images -a -q)
@@ -130,7 +130,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/data/exemplar-001
-          key: mcmicro-exemplar-001
+          key: ex001-2022-02-24
       - name: Test exemplar-001 with Mesmer
         run: |
           docker rmi -f $(docker images -a -q)
@@ -149,7 +149,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/data/exemplar-001
-          key: mcmicro-exemplar-001
+          key: ex001-2022-02-24
       - name: Test exemplar-001 step-by-step
         run: |
           docker rmi -f $(docker images -a -q)
@@ -179,7 +179,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/data/exemplar-002
-          key: mcmicro-exemplar-002-2cycle
+          key: ex002-2022-02-24
       - name: Test exemplar-002
         run: |
           docker rmi -f $(docker images -a -q)
@@ -203,7 +203,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/data/exemplar-001
-          key: mcmicro-exemplar-001
+          key: ex001-2022-02-24
       - name: Test exemplar-001
         run: |
           ./nextflow main.nf --in ~/data/exemplar-001 -profile singularity

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,5 +19,5 @@ nextflow labsyspharm/mcmicro/exemplar.nf --help
 
 * Added a CHANGES file
 * Reworked GPU config profile to expose all GPUs across all platforms
-  * When running MCMICRO on O2, use `-profile O2,GPU` (command, no space) instead of `-profile O2gpu`
+  * When running MCMICRO on O2, use `-profile O2,GPU` (comma, no space) instead of `-profile O2gpu`
 * `quantification` is now the default stopping point

--- a/exemplar.nf
+++ b/exemplar.nf
@@ -5,8 +5,8 @@ if( params.containsKey('help') ) {
     Download MCMICRO exemplar datasets
 
     Expected parameters
-      --name - Name of the exemplar, e.g., "exemplar-001", "exemplar-002", etc.'
-      --path - Path to the destination folder'
+      --name - Name of the exemplar, e.g., "exemplar-001", "exemplar-002", etc.
+      --path - Path to the destination folder
     
     Optional parameters
       --from-cycle - Index of the first cycle to download
@@ -16,11 +16,11 @@ if( params.containsKey('help') ) {
     Examples:
       1. Download the first five cycles of exemplar-001 to the current directory
 
-         nextflow labsyspharm/mcmicro/exemplar.nf --name exemplar-001 --path . --nc 5
+         nextflow run labsyspharm/mcmicro/exemplar.nf --name exemplar-001 --path . --nc 5
 
       2. Download cycle 3 through 9 (inclusively) of exemplar-002 to /data
 
-         nextflow labsyspharm/mcmicro/exemplar.nf \\
+         nextflow run labsyspharm/mcmicro/exemplar.nf \\
            --name exemplar-002 --path /data \\
            --from-cycle 3 --to-cycle 9
     """


### PR DESCRIPTION
* Fixed several typos
* Cleared cache of GitHub Actions tests, allowing them to redownload datasets using the updated `exemplar.nf`
  * The slice of exemplar-002 used for automated tests now spans cycles 6-7 instead of 1-2 (autofluorescence).