### PR TITLE
Robust handling of `.` in filenames

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,4 @@
 tasks:
   - init: |
       cd /workspace; curl -s https://get.nextflow.io | bash
+      ./nextflow mcmicro/exemplar.nf --name exemplar-001 --path .

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 2022-03-04
+
+* The pipeline now correctly carries through image names with `.` in them, e.g., `slide0.ROI7.ome.tif`.
+
 ### 2022-02-24
 
 * Added more flexibility to `exemplar.nf`, which allows for downloading any contiguous set of cycles. For more information, see

--- a/config/modules.config
+++ b/config/modules.config
@@ -67,7 +67,7 @@ params.moduleSeg = [
 params.moduleQuant = [
   name      : 'mcquant',
   container : 'labsyspharm/quantification',
-  version   : '1.5.1'
+  version   : '1.5.2'
 ]
 
 // Modules for cell state computations

--- a/config/modules.config
+++ b/config/modules.config
@@ -24,7 +24,7 @@ params.modulesPM = [
   [
     name      : 'unmicst',
     container : 'labsyspharm/unmicst',
-    version   : '2.7.3',
+    version   : '2.7.4',
     cmd       : 'python /app/unmicstWrapper.py --stackOutput --outputPath .',
     input     : '',
     watershed : 'yes'

--- a/main.nf
+++ b/main.nf
@@ -122,12 +122,12 @@ pre_masks = findFiles(idxStart > 3 && params.tma,
 pre_pmap = findFiles(idxStart == 5,
 		     "${paths[4]}/*/*-pmap.tif",
 		     {error "No probability maps found in ${paths[4]}"})
-    .map{ f -> tuple(f.getParent().getBaseName(), f) }
+    .map{ f -> tuple(f.getParent().getName(), f) }
     .filter{ params.probabilityMaps.contains(it[0]) }
 pre_segMsk = findFiles(idxStart == 6,
 		       "${paths[5]}/**.tif",
 		       {error "No segmentation masks in ${paths[5]}"})
-    .map{ f -> tuple(f.getParent().getBaseName(), f) }.groupTuple()
+    .map{ f -> tuple(f.getParent().getName(), f) }.groupTuple()
 pre_qty    = findFiles(idxStart == 7,
 		       "${paths[6]}/*.csv",
 		       {error "No quantification tables in ${paths[6]}"})
@@ -186,7 +186,6 @@ workflow {
     // Spatial feature tables -> cell state calling
     sft = quantification.out.mix(pre_qty)
     cellstates(sft, modCS)
-
 }
 
 // Write out parameters used

--- a/main.nf
+++ b/main.nf
@@ -182,10 +182,12 @@ workflow {
     // Merge segmentation masks against precomputed ones and append markers.csv
     segMsk = segmentation.out.mix(pre_segMsk)
     quantification(params.moduleQuant, allimg, segMsk, chMrk)
+        .view()
 
     // Spatial feature tables -> cell state calling
     sft = quantification.out.mix(pre_qty)
     cellstates(sft, modCS)
+
 }
 
 // Write out parameters used

--- a/main.nf
+++ b/main.nf
@@ -182,7 +182,6 @@ workflow {
     // Merge segmentation masks against precomputed ones and append markers.csv
     segMsk = segmentation.out.mix(pre_segMsk)
     quantification(params.moduleQuant, allimg, segMsk, chMrk)
-        .view()
 
     // Spatial feature tables -> cell state calling
     sft = quantification.out.mix(pre_qty)

--- a/modules/cell-states.nf
+++ b/modules/cell-states.nf
@@ -14,7 +14,7 @@ workflow cellstates {
 		            file(params."$m") : 'built-in') }
 	.combine(input)
         .map{ mod, _2, _3 ->
-        tuple(mod, _2, _3, "${params.pubDir}/${mod.name}", '') }
+        tuple( '', mod, _2, _3, "${params.pubDir}/${mod.name}", '') }
     worker( inp, '*.{csv,h5ad}', 7 )
 
     emit:

--- a/modules/lib/util.nf
+++ b/modules/lib/util.nf
@@ -1,6 +1,6 @@
 // Extracts a file ID as the first token before delim in the filename.
 def getFileID(f, delim) {
-    f.getBaseName().toString().split(delim).head()
+    f.getName().toString().split(delim).head()
 }
 
 // Extracts an image ID from a filename by dropping extension

--- a/modules/lib/util.nf
+++ b/modules/lib/util.nf
@@ -2,3 +2,9 @@
 def getFileID(f, delim) {
     f.getBaseName().toString().split(delim).head()
 }
+
+// Extracts an image ID from a filename by dropping extension
+def getImageID(f) {
+    tokens = f.getBaseName().toString().replaceFirst(/\.ome$/, "")
+}
+

--- a/modules/lib/worker.nf
+++ b/modules/lib/worker.nf
@@ -1,6 +1,8 @@
 // General worker process
 //
 // Inputs:
+//   tag     - used to match against other files at the pipeline level
+//             the tag is assigned to the outputs without being modified by the worker
 //   module  - a list of module parameters (usually comes from config/modules.config)
 //     .name      - named of the module
 //     .container - associated Docker container image
@@ -43,16 +45,15 @@ process worker {
       saveAs: {fn -> "${task.name}.log"}
 
     input:
-        tuple val(module), file(model), path(inp), val(pubDir), val(fnOut)
+        tuple val(tag), val(module), file(model), path(inp), val(pubDir), val(fnOut)
         val(outfmt)
         val(idxStep)
 
     output:
 
-    // Every worker emits a tuple (input file ID, module used, result)
-    // The input file ID can be used to match against files in other pipeline steps
-    tuple val("${inp.getBaseName().split('\\.').head()}"),
-      val("${module.name}"), path("$outfmt"), emit: res
+    // Every worker emits a tuple (tag, module used, result)
+    // The tag is used to match against files in other pipeline steps
+    tuple val(tag), val("${module.name}"), path("$outfmt"), emit: res
 
     // Modules have the option of producing additional files in plots/ and qc/
     //   subdirectories. These are captured and published to the project directory.

--- a/modules/quantification.nf
+++ b/modules/quantification.nf
@@ -44,8 +44,8 @@ workflow quantification {
 
     // Combine everything based on IDs
     inputs = id_msks.combine(id_imgs, by:0)
-	.map{ id, mtd, msk, img -> tuple("${mtd}-${img.getName()}", img, msk) }
-	.combine( markers )
+      .map{ id, mtd, msk, img -> tuple("${mtd}-${img.getName()}", img, msk) }
+      .combine( markers )
     mcquant(module, inputs)
     
     emit:

--- a/modules/quantification.nf
+++ b/modules/quantification.nf
@@ -25,13 +25,7 @@ process mcquant {
     """
 }
 
-// Pasting the function here as a temporary fix to
-//   an issue with method importing via `include`
-// Revert to include when the issue has been resolved
-// include {getFileID} from './lib/util'
-def getFileID(f, delim) {
-    f.getBaseName().toString().split(delim).head()
-}
+include {getImageID} from './lib/util'
     
 workflow quantification {
     take:
@@ -43,7 +37,7 @@ workflow quantification {
     main:
 
     // Determine IDs of images
-    id_imgs = imgs.map{ f -> tuple(getFileID(f,'\\.'), f) }
+    id_imgs = imgs.map{ f -> tuple(getImageID(f), f) }
 
     // Determine IDs of segmentation masks
     id_msks = segmasks.map{ id, msk -> x = id.split('-',2); tuple(x[1], x[0], msk) }

--- a/modules/quantification.nf
+++ b/modules/quantification.nf
@@ -49,6 +49,5 @@ workflow quantification {
     mcquant(module, inputs)
     
     emit:
-
-    mcquant.out.tables.flatten()
+      mcquant.out.tables.flatten()
 }

--- a/modules/segmentation.nf
+++ b/modules/segmentation.nf
@@ -42,16 +42,9 @@ process s3seg {
     """
 }
 
-include {worker} from './lib/worker'
+include {worker}    from './lib/worker'
+include {getFileID} from './lib/util'
 
-// Pasting the function here as a temporary fix to
-//   an issue with method importing via `include`
-// Revert to include when the issue has been resolved
-// include {getFileID} from './lib/util'
-def getFileID(f, delim) {
-    f.getBaseName().toString().split(delim).head()
-}
-    
 workflow segmentation {
     take:
 


### PR DESCRIPTION
The pipeline now carries image names with `.` in them (e.g., `slide0.ROI7.ome.tif`) through the whole pipeline, while correctly preserving all tokens, instead of dropping everything after the first `.`.