### PR TITLE
Update Ashlar to v1.15.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+### 2022-04-27
+
+* [registration] Updated Ashlar to v1.15.2.
+  * OME-TIFF output now conforms to the official [OME-TIFF pyramid spec](https://docs.openmicroscopy.org/ome-model/6.0.0/ome-tiff/specification.html#sub-resolutions).
+  * Memory usage is dramatically reduced -- registration now only requires enough memory to hold all tiles in the first cycle's reference channel plus a fixed overhead of about 400 MB.
+
 ### 2022-04-22
 
 * By default, MCMICRO was copying `qc/*` files from work directories to the project directory. This was creating unnecessary duplication of potentially large files. The new `--qc-files` option allows users to `copy`, `move` or `symlink` all QC files, providing more flexibility. Example:

--- a/config/O2base.config
+++ b/config/O2base.config
@@ -1,7 +1,5 @@
 includeConfig 'singularity.config'
 
-env.JAVA_TOOL_OPTIONS = "-Xmx100m"
-
 process{
   executor = 'slurm'
   queue    = 'short'

--- a/config/modules.config
+++ b/config/modules.config
@@ -9,7 +9,7 @@ params.moduleIllum = [
 params.moduleRegistr = [
   name      : 'ashlar',
   container : 'labsyspharm/ashlar',
-  version   : '1.14.0'
+  version   : '1.15.2'
 ]
 
 // Module for TMA dearraying

--- a/modules/registration.nf
+++ b/modules/registration.nf
@@ -27,7 +27,7 @@ process ashlar {
     def imgs = lrelPath.collect{ Util.escapeForShell(it) }.join(" ")
     def ilp = "--ffp $lffp --dfp $ldfp"
     if (ilp == '--ffp  --dfp ') ilp = ''  // Don't supply empty --ffp --dfp
-    "ashlar $imgs ${params.ashlarOpts} $ilp --pyramid -f ${params.sampleName}.ome.tif"
+    "ashlar $imgs ${params.ashlarOpts} $ilp -o ${params.sampleName}.ome.tif"
 }
 
 workflow registration {


### PR DESCRIPTION
* OME-TIFF output now conforms to the official OME-TIFF pyramid spec
* Memory usage is dramatically reduced