### PR TITLE
Look for params.yml in the project directory

### DIFF
--- a/lib/mcmicro/Opts.groovy
+++ b/lib/mcmicro/Opts.groovy
@@ -141,6 +141,13 @@ static def parseParams(gp, fns, fnw) {
     // Load default MCMICRO parameters (mcp)
     Map mcp = new Yaml().load(new File(fnw))
 
+    // Check for the presence of a parameter file in the project directory
+    File pproj = new File("${gp.in}/params.yml")
+    if(pproj.exists()) {
+        Map mproj = new Yaml().load(pproj)
+        updateMap(mcp, mproj)
+    }
+
     // Overwrite the parameters from a user-provided file
     if(gp.containsKey('params')) {
         Map mp = new Yaml().load(new File(gp.params))


### PR DESCRIPTION
The pipeline will now look for `params.yml` in the project directory (same location as `markers.csv`).

The overall priority for parameter settings is now as follows:

* (Lowest) Parameter values in `config/defaults.yml`
* Parameter values in `params.yml`, if one found in the directory supplied via `--in`.
* Parameter values in a YAML file provided via `--params`.
* (Highest) Values for individual parameters provided as double-dashed command-line arguments (e.g., `--start-at`)

Closes #411 