### PR TITLE
Temporary fix

### DIFF
--- a/config/schema.yml
+++ b/config/schema.yml
@@ -10,6 +10,8 @@ workflow:
   - segmentation
   - segmentation-channel
   - downstream
+  - ilastik-model
+  - mesmer-model
 deprecated:
   quantification-mask: "--quant-opts '--masks ...'"
   illum: --start-at illumination


### PR DESCRIPTION
Temporary fix until #417 is implemented.
The fix allows MCMICRO to recognize `ilastik-model` and `mesmer-model` workflow parameters.
