### PR TITLE
Reducing memory footprint for Mesmer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 2022-09-08
+
+* Added a `segmentation-recyze` parameter to the `workflow:` section. If set to `true`, MCMICRO will reduce the input image to the channels specified in `segmentation-channel` prior to passing it to the segmentation modules. This can be useful for reducing the memory footprint for modules like Mesmer, which read the entire input image into memory.
+
 ### 2022-08-19
 
 * [registration] Updated Ashlar to v1.17.0.

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -7,6 +7,7 @@ workflow:
   multi-formats: '{.xdce,.nd,.scan,.htd}'
   single-formats: '{.ome.tiff,.ome.tif,.rcpnl,.btf,.nd2,.tif,.czi}'
   segmentation: unmicst
+  segmentation-recyze: false
   downstream: scimap
 options:
   ashlar: -m 30

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -62,7 +62,7 @@ modules:
     -
       name: mesmer
       container: vanvalenlab/deepcell-applications
-      version: 0.3.0
+      version: 0.4.0
       cmd: python /usr/src/app/run_app.py mesmer --squeeze --output-directory . --output-name cell.tif
       input: --nuclear-image
       channel: --nuclear-channel

--- a/config/schema.yml
+++ b/config/schema.yml
@@ -9,6 +9,7 @@ workflow:
   - single-formats
   - segmentation
   - segmentation-channel
+  - segmentation-recyze
   - downstream
   - ilastik-model
   - mesmer-model

--- a/docs/parameters/other.md
+++ b/docs/parameters/other.md
@@ -116,6 +116,7 @@ The [Mesmer](https://doi.org/10.1038/s41587-021-01094-0){:target="_blank"} modul
 Add `segmentation: mesmer` to [workflow parameters]({{site.baseurl}}/parameters/) to enable Mesmer. When running together with UnMicst and/or ilastik, method names must be provided as a list enclosed in square brackets. Additional Mesmer parameters can be provided to MCMICRO by including a `mesmer:` field in the module options section.
 
 * Example `params.yml`:
+
 ``` yaml
 workflow:
   segmentation: mesmer
@@ -152,6 +153,7 @@ MCMICRO integrates three methods for clustering single-cell data. These are [Fas
 Add a `downstream:` field to [workflow parameters]({{site.baseurl}}/parameters/) to select one or more methods. Method names should be provided as a comma-delimited list enclosed in square brackets. Additional method parameters should be provided to MCMICRO by adding `fastpg:`, `scanpy:` and `flowsom:` fields to the module options section.
 
 * Example `params.yml`:
+
 ``` yaml
 workflow:
   stop-at: downstream
@@ -219,6 +221,7 @@ All methods output a `.csv` file annotating individual cells with their cluster 
 Add a `downstream:` field to [workflow parameters]({{site.baseurl}}/parameters/) to select naivestates. When running alongside other cell state inference methods, such as SCIMAP, method names should be provided as a list enclosed in square brackets. Custom marker to cell type (mct) mapping can be provided to naivestates via the `naivestates-model:` workflow parameters, while additional arguments should be specified by including a `naivestates:` field in the module options section.
 
 * Example `params.yml`:
+
 ``` yaml
 workflow:
   stop-at: downstream

--- a/docs/parameters/workflow.md
+++ b/docs/parameters/workflow.md
@@ -69,6 +69,19 @@ workflow:
   segmentation-channel: 1 5
 ```
 
+### `segmentation-recyze` 
+  Whether the image should be reduced to the channels specified in `segmentation-channel` prior to being provided to the segmentation modules.
+
+  * **Valid values:** `true`, `false`
+  * **Default:** `false`
+  * **Example:**
+
+``` yaml
+workflow:
+  segmentation-channel: 5
+  segmentation-recyze: true
+```
+
 ### `ilastik-model`
 
   A custom `.ilp` file to be used as the classifier model for ilastik

--- a/lib/mcmicro/Opts.groovy
+++ b/lib/mcmicro/Opts.groovy
@@ -126,6 +126,14 @@ static def validateWFParams(wfp, fns) {
             throw new Exception("Unrecognized parameter " + key)
         }
     }
+
+    // Additional custom validation(s)
+    if(wfp['segmentation-recyze'] && 
+      !wfp.containsKey('segmentation-channel')) {
+        String msg = "Segmentation-recyze requested but no " +
+            "segmentation-channel provided"
+        throw new Exception(msg)
+    }
 }
 
 /**
@@ -134,7 +142,6 @@ static def validateWFParams(wfp, fns) {
  * @param gp global parameters (usually params in NF space)
  * @param fns filename of the schema
  * @param fnw filename of the default workflow parameters
- * @param fnm filename of the default module specs
  */
 static def parseParams(gp, fns, fnw) {
 

--- a/lib/mcmicro/Opts.groovy
+++ b/lib/mcmicro/Opts.groovy
@@ -209,6 +209,10 @@ static def moduleOpts(module, mcp) {
         // Identify the list of indices
         List idx = wfp['segmentation-channel'].toString().tokenize()
 
+        // Account for recyze, if appropriate
+        if(wfp['segmentation-recyze'])
+            idx = (1..idx.size()).collect{it}
+
         // Account for 0-based indexing
         if(module.idxbase == 0)
             idx = idx.collect{"${(it as int)-1}"}

--- a/main.nf
+++ b/main.nf
@@ -122,7 +122,6 @@ workflow {
     tmacores = dearray.out.cores.mix(pre_cores)
     tmamasks = dearray.out.masks.mix(pre_masks)
 
-
     // Reconcile WSI and TMA processing for downstream segmentation
     allimg = img.wsi.mix(tmacores)
     segmentation(mcp, allimg, tmamasks, pre_pmap)

--- a/modules/segmentation.nf
+++ b/modules/segmentation.nf
@@ -71,11 +71,10 @@ workflow segmentation {
       noCut: !mcp.workflow['segmentation-recyze']
     }
 
-    recyzeOut = roadie(
-      'recyze', recyzeIn.toCut,
-      "--channels ${mcp.workflow['segmentation-channel']}",
-      false, '', ''
-    )
+    // Account for 0-based indexing in recyze
+    chan = mcp.workflow['segmentation-channel'].toString()
+      .tokenize().collect{"${(it as int)-1}"}.join(' ')
+    recyzeOut = roadie('recyze', recyzeIn.toCut, "--channels $chan", false, '', '' )
 
     // Determine IDs of images
     id_cut   = recyzeOut.map{ f -> tuple(Util.getFileID(f, '_crop.ome'), f) }

--- a/modules/segmentation.nf
+++ b/modules/segmentation.nf
@@ -44,7 +44,8 @@ process s3seg {
     """
 }
 
-include { worker }                 from "$projectDir/lib/worker"
+include {worker} from "$projectDir/lib/worker"
+include {roadie} from "$projectDir/roadie"
 
 workflow segmentation {
   take:
@@ -63,10 +64,24 @@ workflow segmentation {
 
     // Compose a mapping for which modules need watershed
     needWS  = moduleSeg.map{ it -> tuple(it.watershed, it.name) }
-    
+
+    // Cut out the segmentation channels if requested
+    recyzeIn = imgs.branch{
+      toCut: mcp.workflow['segmentation-recyze']
+      noCut: !mcp.workflow['segmentation-recyze']
+    }
+
+    recyzeOut = roadie(
+      'recyze', recyzeIn.toCut,
+      "--channels ${mcp.workflow['segmentation-channel']}",
+      false, '', ''
+    )
+
     // Determine IDs of images
-    id_imgs  = imgs.map{ f -> tuple(Util.getImageID(f), f) }
-    
+    id_cut   = recyzeOut.map{ f -> tuple(Util.getFileID(f, '_crop.ome'), f) }
+    id_uncut = recyzeIn.noCut.map{ f -> tuple(Util.getImageID(f), f) }
+    id_imgs = id_cut.mix(id_uncut)
+
     // Determine if there are any custom models for each module
     // Overwrite output filenames with <image>-pmap.tif for pmap generators
     // Publish instance segmentation outputs directly to segmentation/
@@ -100,7 +115,7 @@ workflow segmentation {
 
     // Determine IDs of TMA masks
     // Whole-slide images have no TMA masks
-    id_wsi = imgs.map{ f -> tuple(Util.getImageID(f), 'NO_MASK') }
+    id_wsi = id_imgs.map{ id, _2 -> tuple(id, 'NO_MASK') }
         .filter{ !mcp.workflow['tma'] }
     id_masks = tmamasks.map{ f -> tuple(Util.getFileID(f,'_mask'), f) }
         .mix(id_wsi)

--- a/modules/segmentation.nf
+++ b/modules/segmentation.nf
@@ -72,8 +72,9 @@ workflow segmentation {
     }
 
     // Account for 0-based indexing in recyze
-    chan = mcp.workflow['segmentation-channel'].toString()
-      .tokenize().collect{"${(it as int)-1}"}.join(' ')
+    chan = mcp.workflow.containsKey('segmentation-channel') ?
+      mcp.workflow['segmentation-channel'].toString()
+        .tokenize().collect{"${(it as int)-1}"}.join(' ') : '0'
     recyzeOut = roadie('recyze', recyzeIn.toCut, "--channels $chan", false, '', '' )
 
     // Determine IDs of images

--- a/modules/viz.nf
+++ b/modules/viz.nf
@@ -45,8 +45,10 @@ workflow viz {
         other: true
     }
 
-    stories = roadie('story', inputs.story, '', "${params.in}/qc/story", 'copy')
-        .map{ it -> tuple(Util.getImageID(it), it) }
+    stories = roadie(
+        'story', inputs.story, '', 
+        true, "${params.in}/qc/story", 'copy'
+      ).map{ it -> tuple(Util.getImageID(it), it) }
     images = imgs.map{ it -> tuple(Util.getImageID(it), it) }
 
     inputs = images.combine(stories, by:0)

--- a/roadie.nf
+++ b/roadie.nf
@@ -47,7 +47,7 @@ process showHelp {
 
 process runTask {
     container "${params.contPfx}${params.roadie}"
-    publishDir "${specs.pubDir}", mode: "${specs.pubMode}"
+    publishDir "${specs.pubDir}", mode: "${specs.pubMode}", enabled: "${specs.pub}"
 
     input: each path(code); path(input); val(opts); val(specs)
     output: path("${specs.output}")
@@ -64,6 +64,7 @@ workflow roadie {
     input
     opts
 
+    pub       // Whether to publish results
     pubDir    // Where to publish results to
     pubMode   // What type of publishing (copy, move, symlink)
 
@@ -73,6 +74,7 @@ workflow roadie {
     specs = tasks.containsKey(task) ? tasks[task] : (error "Unknown task.")
 
     // Pad specs with the publication strategy
+    specs.pub     = pub
     specs.pubDir  = pubDir
     specs.pubMode = pubMode  
 


### PR DESCRIPTION
Added a `segmentation-recyze` parameter to the `workflow:` section. If set to `true`, MCMICRO will reduce the input image to the channels specified in `segmentation-channel` prior to passing it to the segmentation modules. This can be useful for reducing the memory footprint for modules like Mesmer, which read the entire input image into memory.

  * **Valid values:** `true`, `false`
  * **Default:** `false`
  * **Example:**

``` yaml
workflow:
  segmentation-channel: 5
  segmentation-recyze: true
```