### PR TITLE
Fix issue staging from S3 paths

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -69,7 +69,7 @@ rawFiles = findFiles('raw', "**${formatPattern}",
 // automatically.
 raw = rawFiles
     .map{ tuple(formatType == "single" ? it : it.parent, it) }
-    .map{ toStage, relPath -> tuple(toStage, toStage.parent.relativize(relPath)) }
+    .map{ toStage, relPath -> tuple(toStage, toStage.parent.relativize(relPath).toString()) }
 
 // Find precomputed intermediates
 pre_dfp   = findFiles0('illumination', "*-dfp.tif")

--- a/modules/illumination.nf
+++ b/modules/illumination.nf
@@ -1,4 +1,5 @@
 import mcmicro.*
+import java.nio.file.Paths
 
 def escapeForImagej(s) {
     // When passing an arbitrary string as an ImageJ macro parameter value, we
@@ -30,6 +31,7 @@ process illumination {
     when: Flow.doirun('illumination', wfp)
     
     script:
+    def relPath = Paths.get(relPath)
     def fn = escapeForImagej(relPath)
     def xpn = escapeForImagej(relPath.subpath(0, 1).toString().tokenize(".")[0])
     def macroParams = Util.escapeForShell(


### PR DESCRIPTION
Work around Nextflow being helpful and staging Path objects even when passed to a process as "val" and not "path". We now explicitly stringify the relative paths we compute for the raw inputs to the registration workflow.