### PR TITLE
Template for adding new MCMICRO modules

### DIFF
--- a/.github/workflows/o2.yml
+++ b/.github/workflows/o2.yml
@@ -2,14 +2,6 @@ name: O2-CI
 
 # Controls when the action will run. 
 on:
-  pull_request:
-    branches: [ master ]
-    paths-ignore:
-      - README.md
-      - CHANGES.md
-      - .gitpod.yml
-      - 'docs/**'
-      - 'setup/**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/o2.yml
+++ b/.github/workflows/o2.yml
@@ -2,15 +2,6 @@ name: O2-CI
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
-  push:
-    branches: [ master ]
-    paths-ignore:
-      - README.md
-      - CHANGES.md
-      - .gitpod.yml
-      - 'docs/**'
-      - 'setup/**'
   pull_request:
     branches: [ master ]
     paths-ignore:
@@ -25,12 +16,11 @@ on:
 
 jobs:
 
-  # Downloads exemplar data from S3 as needed
   test:
     runs-on: O2
     steps:
       - uses: actions/checkout@v3
-      - name: Test on exemplar-001
+      - name: Test on exemplars
         run: |
           module load java
           nextflow main.nf --in ~/exemplar-001 -profile O2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+### 2022-10-01
+
+* Changed the order of tokens in quantification output to make it easier to match filenames against other intermediate.
+
+**Old pattern:** `unmicst-exemplar-001_cell.csv`
+
+**New pattern:** `exemplar-001--unmicst_cell.csv`
+
+The new pattern can now be easily matched against the original `exemplar-001.ome.tif` by cutting the feature table filename at `--`.
+
+* Added `modules/template.nf` documenting how to add new modules to MCMICRO.
+
 ### 2022-09-08
 
 * Added a `segmentation-recyze` parameter to the `workflow:` section. If set to `true`, MCMICRO will reduce the input image to the channels specified in `segmentation-channel` prior to passing it to the segmentation modules. This can be useful for reducing the memory footprint for modules like Mesmer, which read the entire input image into memory.

--- a/modules/quantification.nf
+++ b/modules/quantification.nf
@@ -45,7 +45,8 @@ workflow quantification {
 
     // Combine everything based on IDs
     inputs = id_msks.combine(id_imgs, by:0)
-      .map{ id, mtd, msk, img -> tuple("${mtd}-${img.getName()}", img, msk) }
+      .map{ id, mtd, msk, img -> 
+        tuple("${Util.getImageID(img)}--${mtd}.ome.tif", img, msk) }
       .combine( markers )
     mcquant(mcp, mcp.modules['quantification'], inputs)
     

--- a/modules/template.nf
+++ b/modules/template.nf
@@ -83,11 +83,12 @@ workflow report {
   main:
     
     // Match images against feature tables
-    id_mcp = mcp.map{ it -> tuple(Util.getImageID(it), it) }
-
+    id_imgs = imgs.map{ it -> tuple(Util.getImageID(it), it) }
+    id_sfts = sfts.map{ it -> tuple(Util.getFileID(it, '--'), it) }
 
     // Apply the process to each (image, sft) pair
-
+    id_imgs.combine(id_sfts, by:0)
+        .map{ tag, img, sft -> tuple(img, sft) } | snr
 
     // Return the outputs produced by the tool
   emit:

--- a/modules/template.nf
+++ b/modules/template.nf
@@ -1,0 +1,95 @@
+/*
+A template for adding new modules to MCMICRO
+
+Step 1: Add module specs to config/defaults.yml
+
+Step 2: Modify the code below as needed
+
+Step 3: Run the module from the main workflow in main.nf
+    a: add an include statement to import the relevant workflow. For example:
+        import {report} from "$projectDir/modules/report"
+    b: add a statement calling the module near the bottom of the main workflow:
+        report(mcp, allimg, sft)
+*/
+
+// Import utility functions from lib/mcmicro/*.groovy
+import mcmicro.*
+
+// Process name will appear in the the nextflow execution log
+// While not strictly required, it's a good idea to make the 
+//   process name match your tool name to avoid user confusion
+process snr {
+
+    // Use the container specification from the parameter file
+    // No change to this line is required
+    container "${params.contPfx}${module.container}:${module.version}"
+
+    // Specify the project subdirectory for writing the outputs to
+    // The pattern: specification must match the output: files below
+    // TODO: replace report with the desired output directory
+    // TODO: replace the pattern to match the output: clause below
+    publishDir "${params.in}/report", mode: 'copy', pattern: "*.html"
+
+    // Stores .command.sh and .command.log from the work directory
+    //   to the project provenance
+    // No change to this line is required
+    publishDir "${Flow.QC(params.in, 'provenance')}", mode: 'copy', 
+      pattern: '.command.{sh,log}',
+      saveAs: {fn -> fn.replace('.command', "${module.name}-${task.index}")}
+    
+    // Inputs for the process
+    // mcp - MCMICRO parameters (workflow, options, etc.)
+    // module - module specifications (name, container, options, etc.)
+    // img/sft - pairs of images and their matching spatial feature tables
+  input:
+    val mcp
+    val module
+    tuple path(img), path(sft)
+
+    // Process outputs that should be captured and 
+    //  a) returned as results
+    //  b) published to the project directory
+    // TODO: replace *.html with the pattern of the tool output files
+  output:
+    path("*.html"), emit: results
+
+    // Provenance files -- no change is needed here
+    tuple path('.command.sh'), path('.command.log')
+
+    // Specifies whether to run the process
+    // Here, we simply take the flag from the workflow parameters
+    // TODO: change snr to match the true/false workflow parameter in defaults.yml
+  when: mcp.workflow["snr"]
+
+    // The command to be executed inside the tool container
+    // The command must write all outputs to the current working directory (.)
+    // Opts.moduleOpts() will identify and return the appropriate module options
+    """    
+    python /app/mytool.py --image $img --features $sft ${Opts.moduleOpts(module, mcp)}
+    """
+}
+
+workflow report {
+  
+    // Inputs:
+    // mcp - MCMICRO parameters (workflow, options, etc.)
+    // imgs - images
+    // sfts - spatial feature tables
+  take:
+    mcp
+    imgs
+    sfts
+
+  main:
+    
+    // Match images against feature tables
+    id_mcp = mcp.map{ it -> tuple(Util.getImageID(it), it) }
+
+
+    // Apply the process to each (image, sft) pair
+
+
+    // Return the outputs produced by the tool
+  emit:
+    snr.out.results
+}

--- a/modules/template.nf
+++ b/modules/template.nf
@@ -3,13 +3,46 @@ A template for adding new modules to MCMICRO
 
 Step 1: Add module specs to config/defaults.yml
 
+  a: Add a flag specifying whether the module should be run to workflow:
+  b: Add default module options to options:
+  c: Add module name and container specs to modules:
+
+  For example, support we wanted to add a module that produces a QC report
+    about the signal-to-noise ratio (snr). The three additions to defaults.yml
+    may then look as follows:
+
+  workflow:
+    report: false
+  options:
+    snr: --cool-parameter 42
+  modules:
+    report:
+      name: snr
+      container: myorganization/snr
+      version: 1.0.0
+
 Step 2: Modify the code below as needed
 
 Step 3: Run the module from the main workflow in main.nf
-    a: add an include statement to import the relevant workflow. For example:
-        import {report} from "$projectDir/modules/report"
-    b: add a statement calling the module near the bottom of the main workflow:
-        report(mcp, allimg, sft)
+
+  a: add an include statement to import the relevant workflow. For example:
+
+    ...
+    include {downstream}     from "$projectDir/modules/downstream"
+    include {viz}            from "$projectDir/modules/viz"
+    include {report}         from "$projectDir/modules/report"   // <- importing the new module
+  
+  b: add a statement calling the module near the bottom of the main workflow:
+
+    ...
+    downstream(mcp, sft)
+
+    report(mcp, allimg, sft)     // <- calling the new module
+
+    // Vizualization
+    viz(mcp, allimg)
+    ...
+
 */
 
 // Import utility functions from lib/mcmicro/*.groovy
@@ -59,7 +92,7 @@ process snr {
     // Specifies whether to run the process
     // Here, we simply take the flag from the workflow parameters
     // TODO: change snr to match the true/false workflow parameter in defaults.yml
-  when: mcp.workflow["snr"]
+  when: mcp.workflow["report"]
 
     // The command to be executed inside the tool container
     // The command must write all outputs to the current working directory (.)


### PR DESCRIPTION
* Changed the order of tokens in quantification output to make it easier to match filenames against other intermediate.

**Old pattern:** `unmicst-exemplar-001_cell.csv`

**New pattern:** `exemplar-001--unmicst_cell.csv`

The feature table filename can now be easily matched against the original `exemplar-001.ome.tif` by cutting at `--`.

* Added `modules/template.nf` documenting how to add new modules to MCMICRO.