### PR TITLE
Expanded parsing of -params-file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,31 @@
+### 2022-11-01
+
+* Expanded the parsing of the parameter file specified via `-params-file`. This allows for the entire workflow/options/modules parameter structure to be pasted directly inside the "Pipeline parameters" field of a Nextflow Tower launchpad.
+
+### 2022-10-28
+
+* Added a background subtraction module. The module can be turned on by setting the `background` workflow option to `true`:
+
+``` yaml
+workflow:
+  background: true
+```
+
+### 2022-10-26
+
+* Added cellpose. The module can now be selected as one of the `segmentation` workflow settings:
+
+``` yaml
+workflow:
+  segmentation: cellpose
+```
+
+### 2022-10-19
+
+* Added a roadie script for generating image pyramids. Example usage:
+
+`nextflow run labsyspharm/mcmicro/roadie.nf --in simple.tif --out pyramid.ome.tif`
+
 ### 2022-10-01
 
 * Changed the order of tokens in quantification output to make it easier to match filenames against other intermediate.

--- a/lib/mcmicro/Opts.groovy
+++ b/lib/mcmicro/Opts.groovy
@@ -87,8 +87,8 @@ static def cleanParams(pars, mspecs) {
     def names = collectNames(mspecs)
 
     // Protected keywords
-    keywords = ['in', 'cont-pfx', 'roadie', 'workflow',
-                'options', 'modules', 'params']
+    def keywords = ['in', 'cont-pfx', 'roadie', 'workflow',
+        'options', 'modules', 'params']
 
     // Clean up the parameter list
     // Separate workflow parameters from module options

--- a/lib/mcmicro/Opts.groovy
+++ b/lib/mcmicro/Opts.groovy
@@ -86,11 +86,15 @@ static def cleanParams(pars, mspecs) {
     // Identify all module names
     def names = collectNames(mspecs)
 
+    // Protected keywords
+    keywords = ['in', 'cont-pfx', 'roadie', 'workflow',
+                'options', 'modules', 'params']
+
     // Clean up the parameter list
     // Separate workflow parameters from module options
     pars.findAll{ key, val ->
         Opts.camel2snake(key) == key &&
-        !['in', 'cont-pfx', 'roadie', 'modules', 'params'].contains(key)
+        !keywords.contains(key)
     }.each{ key, val ->
         String keyc = key.replaceAll( /-opts$/, '' )
         if(names.contains(keyc))
@@ -161,11 +165,10 @@ static def parseParams(gp, fns, fnw) {
         updateMap(mcp, mp)
     }
 
-    // Override the module specs, if specified
-    if(gp.containsKey('modules')) {
-        Map mm = new Yaml().load(new File(gp.modules))
-        updateMap(mcp.modules, mm)
-    }
+    // Override specific sections of parameters, if specified in -params-file
+    if(gp.containsKey('workflow')) updateMap(mcp.workflow, gp.workflow)
+    if(gp.containsKey('options')) updateMap(mcp.options, gp.options)
+    if(gp.containsKey('modules')) updateMap(mcp.modules, gp.modules)
 
     // Override workflow parameters and module options with
     //   command-line arguments (cla), as appropriate


### PR DESCRIPTION
* Expanded the parsing of the parameter file specified via `-params-file`. This allows for the entire workflow/options/modules parameter structure to be pasted directly inside the "Pipeline parameters" field of a Nextflow Tower launchpad.

* Documented all recent developments in `CHANGES.md`

Closes #455 