### PR TITLE
Fix illumination output filename collision

### DIFF
--- a/modules/illumination.nf
+++ b/modules/illumination.nf
@@ -33,7 +33,7 @@ process illumination {
     script:
     def relPath = Paths.get(relPath)
     def fn = escapeForImagej(relPath)
-    def xpn = escapeForImagej(relPath.subpath(0, 1).toString().tokenize(".")[0])
+    def xpn = escapeForImagej(relPath.subpath(0, 1))
     def macroParams = Util.escapeForShell(
         """filename=$fn,output_dir=".",experiment_name=$xpn"""
     )


### PR DESCRIPTION
Instead of trying to be clever and stripping dotted suffixes from the raw input filenames to generate the filename base for the output of the illumination module, just use the entire input filename. This fixes the issue where filenames with dots in their can lead to collusions as in #331.  For single-file formats like .rcpnl, the output filenames will now look like foo.rcpnl-ffp.tif which is a bit odd but won't cause any problems inside mcmicro.

Fixes #331