### PR TITLE
Update mcmicro-ilastik container version

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -57,7 +57,7 @@ modules:
     -
       name: ilastik
       container: labsyspharm/mcmicro-ilastik
-      version: 1.5.1
+      version: 1.6.0
       cmd: python /app/mc-ilastik.py --output .
       input: --input
       model: --model


### PR DESCRIPTION
Updated mcmicro-ilastik version from 1.5.1 to 1.6.0