### PR TITLE
Ilastik version bump

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -57,7 +57,7 @@ modules:
     -
       name: ilastik
       container: labsyspharm/mcmicro-ilastik
-      version: 1.6.0
+      version: 1.6.1
       cmd: python /app/mc-ilastik.py --output .
       input: --input
       model: --model


### PR DESCRIPTION
Another version bump, this time to the new stable release 1.4.0, which is used in mcmicro-ilastik 1.6.1.