### PR TITLE
Modified globbing rules for mcquant's --masks

### DIFF
--- a/modules/quantification.nf
+++ b/modules/quantification.nf
@@ -23,6 +23,7 @@ process mcquant {
     when: Flow.doirun('quantification', mcp.workflow)
 
     """
+    shopt -s nullglob
     python /app/CommandSingleCellExtraction.py --image $tag \
     ${Opts.moduleOpts(module, mcp)} --output . --channel_names $ch
     """


### PR DESCRIPTION
Adds a shell option to the mcquant's environment that will drop any globs for which there are no matches, allowing settings like

```
options:
  mcquant: --masks cell*.tif cyto*.tif
```

to function as intended when either `cell*.tif` or `cyto*.tif` are missing.