### PR TITLE
Set pyramid `downscale_factor=2` for compatibility with recyze

### DIFF
--- a/roadie/scripts/pyramidize.py
+++ b/roadie/scripts/pyramidize.py
@@ -1,24 +1,59 @@
-import os
 import argparse
-import palom.reader
+import pathlib
+
+import ome_types
 import palom.pyramid
+import palom.reader
+
+
+def detect_pixel_size(img_path):
+    try:
+        metadata = ome_types.from_tiff(img_path)
+        pixel_size = metadata.images[0].pixels.physical_size_x
+    except Exception as err:
+        print(err)
+        print()
+        print('Pixel size detection using ome-types failed')
+        pixel_size = None
+    return pixel_size
+
+
+def _file(path):
+    path = pathlib.Path(path)
+    if path.is_file(): return path
+    else: raise FileNotFoundError(path.resolve())
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--in', type=str, required=True, help="Input Image Path")
-    parser.add_argument('--out', type=str, required=False, help="Output JSON Path")
+    parser.add_argument(
+        '--in',
+        nargs='+',
+        type=_file,
+        required=True,
+        help="Input Image Paths"
+    )
+    parser.add_argument('--out', type=str, required=False, help="Output Image Path")
     args = parser.parse_args()
 
+    in_paths = vars(args)['in']
     # Automatically infer the output filename, if not specified
-    in_path = vars(args)['in']
-    out_path = args.out
-    if out_path is None:
-        tokens = os.path.basename(in_path).split(os.extsep)
-        if len(tokens) < 2:       stem = in_path
-        elif tokens[-2] == "ome": stem = os.extsep.join(tokens[0:-2])
-        else:                     stem = os.extsep.join(tokens[0:-1])
-        out_path = stem + ".ome.tif"
+    if args.out is None:
+        in_path = in_paths[0]
+        stem = in_path.stem
+        out_path = in_path.parent / f"{stem}.ome.tif"
+    else:
+        out_path = pathlib.Path(args.out)
+    # pixel data is read into RAM lazily, cannot overwrite input file
+    assert out_path not in in_paths
+
+    # Detect pixel size in ome-xml
+    pixel_size = detect_pixel_size(in_path)
+    if pixel_size is None: pixel_size = 1
 
     # Use palom to pyramidize the input image
-    img = palom.reader.OmePyramidReader(in_path)
-    palom.pyramid.write_pyramid([img.pyramid[0]], out_path)
+    readers = [palom.reader.OmePyramidReader(in_path) for in_path in in_paths]
+    mosaics = [reader.pyramid[0] for reader in readers]
+    palom.pyramid.write_pyramid(
+        mosaics, out_path, downscale_factor=2, pixel_size=pixel_size
+    )


### PR DESCRIPTION
Palom defaults to write 4x downscale pyramid which requires changes of an unexposed parameter in recyze. This PR set the downscale factor to 2x and also allows combining multiple images into a single pyramid. 