### PR TITLE
Handling membrane images in Mesmer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 2023-06-16
+
+* If `--membrane-channel` is provided to Mesmer options, MCMICRO will automatically pass the input image both as `--nuclear-image` and as `--membrane-image` to the Mesmer CLI.
+
 ### 2023-03-10
 
 * [viz] Auto-Minerva story construction will now read channel names from `markers.csv`

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -70,6 +70,7 @@ modules:
       version: 0.4.0
       cmd: python /usr/src/app/run_app.py mesmer --squeeze --output-directory . --output-name cell.tif
       input: --nuclear-image
+      membrane-input: --membrane-image
       channel: --nuclear-channel
       idxbase: 0
       watershed: 'no'

--- a/lib/worker.nf
+++ b/lib/worker.nf
@@ -68,10 +68,18 @@ process worker {
     //   if they all use the same model file.
     script:
 
-    // Find module specific parameters and compose a command
-    def cmd = "${module.cmd} ${module.input} $inp ${Opts.moduleOpts(module, mcp)}"
+    // Find module specific parameters
+    def opts = "${Opts.moduleOpts(module, mcp)}"
+
+    // Determine if we need to pass the input as a membrane image also
+    def mmbr = (opts.indexOf('membrane') > -1 && module.containsKey('membrane-input')) ?
+      "${module['membrane-input']} $inp" : ""
+
+    // Compose the command
+    def cmd = "${module.cmd} ${module.input} $inp $mmbr $opts"
     String m = "${module.name}-model"
 
+    // Create a copy of the model file if one is provided
     if( mcp.workflow.containsKey(m) ) {
       def mdlcp = "cp-${model.name}"
       """


### PR DESCRIPTION
MCMICRO will check for the presence of "membrane" in module options. If the substring exists and `membrane-input` is defined in the corresponding module config, its value will be used to pass the input image as the membrane image. In particular, this will now properly handle `--membrane-image` in Mesmer.