### PR TITLE
Update s3seg/large version and imagej-rolling-ball version

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -45,10 +45,10 @@ modules:
     -
       name: imagej-rolling-ball
       container: yuanchen12/imagej-rolling-ball
-      version: v2023.8.6
+      version: v2023.9.1
       cmd: |-
         cp ${marker} markers_bs.csv && \
-          rolling-ball --imagej_version="/tmp/Fiji.app" ${image}
+          rolling-ball --imagej_version="/home/mambauser/Fiji.app" ${image}
   segmentation:
     -
       name: unmicst
@@ -100,7 +100,7 @@ modules:
   watershed:
     name: s3seg
     container: labsyspharm/s3segmenter
-    version: 1.5.3
+    version: 1.5.5
     channel: --probMapChan
     idxbase: 1
   quantification:


### PR DESCRIPTION
- s3seg/large v1.5.5 now applies image file compression to the output files
- imagej-rolling-ball now moved the local Fiji.app to mambauser's home directory (`/home/mambauser/`). Singularity execution is doing something to the `/tmp/` and the Fiji.app under `/tmp` cannot be found