### PR TITLE
Backsub version bump and updated documentation

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -37,7 +37,7 @@ modules:
     -
       name: backsub
       container: ghcr.io/schapirolabor/background_subtraction
-      version: v0.3.3
+      version: v0.4.1
       cmd: |-
         python3 /background_subtraction/background_sub.py \
           -r ${image} -m ${marker} \

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -12,7 +12,7 @@ MCMICRO is a multi-institutional effort with contributions by the following deve
 |Institution| People|
 |---|---|
 |**Harvard Medical School**|[Artem Sokolov](https://scholar.harvard.edu/artem-sokolov)<br>[Clarence Yapp](https://scholar.harvard.edu/clarence/who-clarence)<br>[Jeremy Muhlich](https://github.com/jmuhlich)<br>[Yu-An Chen](https://github.com/Yu-AnChen)<br>[Clemens Hug](https://github.com/clemenshug)<br>[Greg Baker](https://github.com/gjbaker)<br>[Juha Ruokonen](https://github.com/Juha-Ruokonen)<br>[Edward Novikov](https://github.com/edn314)<br>[Robert Krueger](https://github.com/kruegert)|
-|**Heidelberg University**|[Denis Schapiro](https://twitter.com/denisschapiro)<br>[Florian Wünnemann](https://github.com/FloWuenne)<br>[Miguel Ibarra](https://github.com/migueLib)<br>[Krešimir Beštak](https://github.com/kbestak)|
+|**Heidelberg University**|[Denis Schapiro](https://twitter.com/denisschapiro)<br>[Florian Wünnemann](https://github.com/FloWuenne)<br>[Miguel Ibarra](https://github.com/migueLib)<br>[Krešimir Beštak](https://github.com/kbestak)<br>[Victor Perez](https://github.com/VictorDidier)|
 |**Oregon Health and Sciences University**|[Allison Creason](https://www.ohsu.edu/people/allison-creason-phd)<br>[Jeremy Goecks](https://www.ohsu.edu/people/jeremy-goecks-phd)<br>Daniel Persson<br>[Qiang Gu](https://github.com/qiagu)<br>[Luke Sargent](https://github.com/luke-c-sargent)<br>[Cameron Watson](https://github.com/CameronFRWatson)<br>Luke Strgar|
 |**Dana-Farber Cancer Institute**|[Ajit Johnson](https://ajitjohnson.com/)|
 |**Vanderbilt University**|[Darren Tyson](https://medschool.vanderbilt.edu/cancer-biology/person/darren-tyson-ph-d/)|

--- a/docs/parameters/other.md
+++ b/docs/parameters/other.md
@@ -315,6 +315,10 @@ Nextflow will write all outputs to the `cell-states/naivestates/` subdirectory w
 
 ---
 
+## Backsub
+{: .fw-500}
+
+
 ### Description
 `Backsub` is an autofluorescence subtraction module for sequential IF images. It performs pixel-level subtraction on large `.ome.tif` images primarily developed with the Lunaphore COMET platform outputs in mind.
 

--- a/docs/parameters/other.md
+++ b/docs/parameters/other.md
@@ -315,21 +315,19 @@ Nextflow will write all outputs to the `cell-states/naivestates/` subdirectory w
 
 ---
 
-## Backsub
-{: .fw-500}
-
-
 ### Description
-`Backsub` is a background subtraction module for sequential IF images. It performs autofluorescence, pixel-level subtraction on large `.ome.tif` images primarily developed with the Lunaphore COMET platform outputs in mind.
+`Backsub` is an autofluorescence subtraction module for sequential IF images. It performs pixel-level subtraction on large `.ome.tif` images primarily developed with the Lunaphore COMET platform outputs in mind.
 
 ### Usage
-By default, MCMICRO assumes background subtraction should not be performed. Add `background: true` to [module options]({{site.baseurl}}/parameters/) to indicate it should be.
+By default, MCMICRO assumes background subtraction should not be performed. Add `background: true` to [module options]({{site.baseurl}}/parameters/workflow.html#background) to indicate it should be. By default, the `background-method` parameter is set to `backsub`. 
+If channels are removed using this module, and `segmentation-channel` is specified, it should be kept in mind that the index provided with `segmentation-channel` would refer to the index after channel removal.
 
 * Example `params.yml`:
 
 ``` yaml
 workflow:
   background: true
+  background-method: backsub
 ```
 
 * Running outside of MCMICRO: [Instructions](https://github.com/SchapiroLabor/Background_subtraction){:target="_blank"}.
@@ -344,4 +342,12 @@ workflow:
 * A pyramidal, tiled `.ome.tif`. Nextflow will write the output file to `background/` within the project directory.
 * A modified `markers.csv` to match the background subtracted image.
 
-[Back to top](./other.html#other-modules){: .btn .btn-purple} [Back to main modules](./){: .btn .btn-outline} 
+### Optional arguments
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `--pixel-size` | `None` | The resolution of the image in microns-per-pixel. If not provided, it is read from metadata. If that is not possible, 1 is assigned. |
+| `--tile-size` | `1024` | Tile size used for pyramid image generation.|
+| `--chunk-size` | `5000` | Chunk size used for lazy loading and processing the image.|
+
+[Back to Other Modules](./core.html#other-modules){: .btn .btn-purple} [Back to top](./core){: .btn .btn-outline} 

--- a/docs/parameters/workflow.md
+++ b/docs/parameters/workflow.md
@@ -148,7 +148,7 @@ workflow:
 {: .fs-4}
 {: .fw-300}
 
-  * **Valid values:** One or more of `unmicst`, `ilastik`, `mesmer`, `cypository`, specified as a YAML list
+  * **Valid values:** One or more of `unmicst`, `ilastik`, `mesmer`, `cypository`, `cellpose` specified as a YAML list
   * **Default:** `unmicst`
   * **Example:**
   


### PR DESCRIPTION
* I've updated the documentation for Mesmer usage so that it is clear `segmentation-channel` and `segmentation-recyze` params should be used to decrease memory usage.
* I've added `cellpose` to the list of valid `segmentation-method` options
* Bumped Backsub version to v0.4.1, where I've reworked it completely and fixed the issue with extreme memory usage and added appropriate documentation for a couple of new params.