### PR TITLE
Version bump for s3seg

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -100,7 +100,7 @@ modules:
   watershed:
     name: s3seg
     container: labsyspharm/s3segmenter
-    version: 1.5.5
+    version: 1.5.6
     channel: --probMapChan
     idxbase: 1
   quantification:


### PR DESCRIPTION
The new version of `s3seg` updates `ome_types` to 0.4.5, allowing it to handle images that rely on newer XML metadata standards.