### PR TITLE
Update O2.md to fix broken link

### DIFF
--- a/docs/troubleshooting/O2.md
+++ b/docs/troubleshooting/O2.md
@@ -7,7 +7,7 @@ parent: Troubleshooting
 
 # Troubleshooting MCMICRO on O2
 
-The following are common problems users encounter on O2. For more information, please review [the instructions for running MCMICRO on O2]({{ site.baseurl }}/troubleshooting/O2.html).
+The following are common problems users encounter on O2. For more information, please review [the instructions for running MCMICRO on O2]({{ site.baseurl }}/platforms/run-O2.html).
 
 ### I am getting `java: command not found`
 


### PR DESCRIPTION
The link at the top of the page pointed to the same page. Redirected the link to the O2 page under Platforms.