### PR TITLE
Added support for multiple samples in raw/

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,74 @@
+### 2024-02-25
+
+* Added support for multiple samples in `raw/` subdirectory. If multiple images share the same markers and should be processed with the same set of parameters, they can be placed as subdirectories of `raw/`. In other words, instead of structuring the data as multiple projects:
+
+```
+image1/
+  markers.csv
+  params.yml
+  raw/
+    tile1.rcpnl
+    tile2.rcpnl
+
+image2/
+  markers.csv
+  params.yml
+  raw/
+    tile1.rcpnl
+    tile2.rcpnl
+```
+
+they can be consolidated under the same project folder:
+
+```
+myproject/
+  markers.csv
+  params.yml
+  raw/
+    image1/
+      tile1.rcpnl
+      tile2.rcpnl
+    image2/
+      tile1.rcpnl
+      tile2.rcpnl
+```
+
+### 2024-01-31
+
+* Added support for ASHLAR's [fileseries/filepattern](https://forum.image.sc/t/ashlar-how-to-pass-multiple-images-to-be-stitched/49864) feature. The patterns can be provided directly via ASHLAR's options:
+
+``` yaml
+options:
+  ashlar: fileseries|...
+```
+
+### 2023-12-21
+
+* Added a config parameter controlling how intermediates are published to project directory. The behavior can be controlling by adding the following to `custom.config`:
+
+```
+params.publish_dir_mode = 'copy'
+```
+
+and providing it to the pipeline with
+
+```
+nextflow run labsyspharm/mcmicro --in exemplar-001 -c custom.config
+```
+
+The valid values for `publish_dir_mode` can be found in [Nextflow documentation](https://nextflow.io/docs/latest/process.html#publishdir) of `publishDir`, argument `mode`.
+
+### 2023-08-29
+
+* Added ImageJ rolling ball background subtraction module
+
+The new module can be selected by adding the following to `params.yml`:
+``` yaml
+workflow:
+  background: true
+  background-method: imagej-rolling-ball
+```
+
 ### 2023-06-16
 
 * If `--membrane-channel` is provided to Mesmer options, MCMICRO will automatically pass the input image both as `--nuclear-image` and as `--membrane-image` to the Mesmer CLI.

--- a/lib/mcmicro/Util.groovy
+++ b/lib/mcmicro/Util.groovy
@@ -1,5 +1,13 @@
 package mcmicro
 
+static def getSampleName(f, rawdir) {
+    // Resolve paths relative to the input project directory
+    String rel = rawdir.relativize(f).toString()
+    rel.contains('/') ? rel.split('/').head() : 
+        rawdir.parent.getName()
+}
+
+
 /**
  * Extracts a file ID as the first token before delim in the filename
  *

--- a/main.nf
+++ b/main.nf
@@ -95,10 +95,11 @@ include {background}     from "$projectDir/modules/background"
 
 // Define the primary mcmicro workflow
 workflow {
-    illumination(wfp, mcp.modules['illumination'], raw)
-    registration(mcp, raw,
+    illumination(mcp, raw).view()
+/*    registration(mcp, raw,
 		 illumination.out.ffp.mix( pre_ffp ),
 		 illumination.out.dfp.mix( pre_dfp ))
+    .view()
     img = registration.out.mix(pre_img)
 
     // Should background subtraction be applied?
@@ -150,7 +151,7 @@ workflow {
     downstream(mcp, sft)
 
     // Vizualization
-    viz(mcp, allimg, chMrk)
+    viz(mcp, allimg, chMrk)*/
 }
 
 // Write out parameters used

--- a/main.nf
+++ b/main.nf
@@ -120,8 +120,7 @@ workflow {
     registration(mcp, raw,
 		 illumination.out.ffp.mix( pre_ffp ),
 		 illumination.out.dfp.mix( pre_dfp ))
-    .view()
-/*    img = registration.out.mix(pre_img)
+    img = registration.out.mix(pre_img)
 
     // Should background subtraction be applied?
     img = img.
@@ -172,7 +171,7 @@ workflow {
     downstream(mcp, sft)
 
     // Vizualization
-    viz(mcp, allimg, chMrk)*/
+    viz(mcp, allimg, chMrk)
 }
 
 // Write out parameters used

--- a/modules/illumination.nf
+++ b/modules/illumination.nf
@@ -1,8 +1,6 @@
 import mcmicro.*
 import java.nio.file.Paths
 
-include {prepare} from "$projectDir/modules/registration"
-
 def escapeForImagej(s) {
     // When passing an arbitrary string as an ImageJ macro parameter value, we
     // must backslash-escape backslashes and double-quotes and wrap the whole
@@ -10,7 +8,7 @@ def escapeForImagej(s) {
     "\"" + s.toString().replace("\\", "\\\\").replace("\"", "\\\"") + "\""
 }
 
-process basic {
+process illumination {
     container "${params.contPfx}${module.container}:${module.version}"
 
     // Output profiles
@@ -27,8 +25,8 @@ process basic {
       val module
       tuple val(sname), path(raw), val(relPath) // raw is only for staging, use relPath for paths
     output:
-      path '*-dfp.tif', emit: dfp
-      path '*-ffp.tif', emit: ffp
+      tuple val(sname), path('*-dfp.tif'), emit: dfp
+      tuple val(sname), path('*-ffp.tif'), emit: ffp
       tuple path('.command.sh'), path('.command.log')
 
     when: Flow.doirun('illumination', wfp)
@@ -45,19 +43,4 @@ process basic {
       --run /opt/fiji/imagej_basic_ashlar.py \
       $macroParams
     """
-}
-
-workflow illumination {
-  take:
-    mcp     // MCMICRO parameters as read by Opts.parseParams()
-    raw     // raw image tiles
-
-  main:
-    rawPrep = prepare(raw, mcp.workflow)
-
-    // basic(mcp.workflow, mcp.modules['illumination'], rawPrep)
-
-  emit:
-    rawPrep
-//    basic.out
 }

--- a/modules/registration.nf
+++ b/modules/registration.nf
@@ -50,6 +50,23 @@ workflow registration {
       dfp     // dark-field profiles
 
     main:
+
+      rawdir = file("${params.in}/raw")
+      rawFiles.map(it -> Util.getSampleName(it, rawdir)).view()
+
+      // Here we assemble tuples of 1) path to stage for each raw image (might be a
+      // directory) and 2) relative path to the main file for each image. Processes
+      // must input the first as a path and the second as a val to avoid incorrect or
+      // redundant file staging. They must also only use the second (relative) path to
+      // construct pathnames for scripts etc. mcmicro.Util.escapePathForShell must be
+      // used when interpolating these paths into script strings, as we are bypassing
+      // the normal way that paths are passed to channels which handles this escaping
+      // automatically.
+      raw = rawFiles
+          .map{ tuple(formatType == "single" ? it : it.parent, it) }
+          .map{ toStage, relPath -> tuple(toStage, toStage.parent.relativize(relPath).toString()) }
+
+
       rawst = raw.toSortedList{a, b -> a[0] <=> b[0]}.transpose()
       sampleName  = file(params.in).name
 


### PR DESCRIPTION
If multiple images share the same markers and parameter settings, they can now be placed as subdirectories of `raw/`. In other words, instead of structuring the data as multiple projects:

```
image1/
  markers.csv
  params.yml
  raw/
    tile1.rcpnl
    tile2.rcpnl

image2/
  markers.csv
  params.yml
  raw/
    tile1.rcpnl
    tile2.rcpnl
```

they can be consolidated under the same project folder:

```
myproject/
  markers.csv
  params.yml
  raw/
    image1/
      tile1.rcpnl
      tile2.rcpnl
    image2/
      tile1.rcpnl
      tile2.rcpnl
```