### PR TITLE
Update coreograph to 2.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           ./nextflow main.nf --in ~/data/exemplar-001 ${{ matrix.params }}
           ls -R ~/data/exemplar-001
       - name: Upload processed result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'push' && contains(matrix.params, 'viz') }}
         with:
           name: exemplar-001

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -33,7 +33,7 @@ modules:
   dearray:
     name: coreograph
     container: labsyspharm/unetcoreograph
-    version: 2.2.9
+    version: 2.4.0
     cmd: python /app/UNetCoreograph.py --outputPath .
     input: --imagePath
   staging:

--- a/modules/dearray.nf
+++ b/modules/dearray.nf
@@ -1,13 +1,11 @@
 import mcmicro.*
 
-include {roadie} from "$projectDir/roadie"
-
 process coreograph {
     container "${params.contPfx}${module.container}:${module.version}"
     
-    // Output -- publish masks only, images need to be pyramidized
+    // Output
     publishDir "${params.in}/dearray", mode: "${params.publish_dir_mode}",
-      pattern: '**mask.tif'
+      pattern: '{*.ome.tif,**mask.tif}'
 
     // QC
     publishDir "${Flow.QC(params.in, module.name)}",
@@ -24,7 +22,7 @@ process coreograph {
       path s
     
     output:
-      path "**{,[A-Z],[A-Z][A-Z]}{[0-9],[0-9][0-9]}.tif", emit: cores
+      path "*.ome.tif", emit: cores
       path "**_mask.tif", emit: masks
       path "TMA_MAP.tif"
       path "centroidsY-X.txt"
@@ -45,11 +43,7 @@ workflow dearray {
   main:
     coreograph(mcp, mcp.modules['dearray'], tma)
 
-    // Pass the core images through palom to pyramidize them
-    inputs = coreograph.out.cores.flatten()
-    roadie('pyramidize', inputs, '', true, "${params.in}/dearray", "${params.publish_dir_mode}")
-
   emit:
-    cores = roadie.out
+    cores = coreograph.out.cores.flatten()
     masks = coreograph.out.masks.flatten()
 }


### PR DESCRIPTION
This version outputs ome-tiff pyramids already so the roadie/pyramidize step is no longer necessary.