### PR TITLE
Bump coreograph to 2.4.1

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -33,7 +33,7 @@ modules:
   dearray:
     name: coreograph
     container: labsyspharm/unetcoreograph
-    version: 2.4.0
+    version: 2.4.1
     cmd: python /app/UNetCoreograph.py --outputPath .
     input: --imagePath
   staging:


### PR DESCRIPTION
Adds support for reading tiffs with LZW compression.