### PR TITLE
Update illumination to 1.4.0

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -25,7 +25,7 @@ modules:
   illumination:
     name: basic
     container: labsyspharm/basic-illumination
-    version: 1.1.1
+    version: 1.4.0
   registration:
     name: ashlar
     container: labsyspharm/ashlar


### PR DESCRIPTION
This version of the docker container has an up-to-date install of Fiji (the official fiji/fiji images are all 3 years out of date). The update was specifically requested to handle the latest .czi files with internal zstd compression, but it's a good idea to keep Fiji (and thus BioFormats) updated in general.